### PR TITLE
Fixed plot moving panicking on `wasm32-unknown-unknown` target

### DIFF
--- a/src/plot_state.rs
+++ b/src/plot_state.rs
@@ -1,9 +1,10 @@
-use std::{sync::Arc, time::Instant};
+use std::sync::Arc;
 
 use glam::{DVec2, Vec2};
 use iced::{
     Color, Rectangle, keyboard,
     mouse::{self, Event},
+    time::Instant
 };
 
 use crate::{


### PR DESCRIPTION
On `wasm32-unknown-unknown` target `std::time` functionality is not implemented and immediately panics.

This PR exports iced's `iced::time::Instant` instead of `std::time::Instant` because it uses `web_time::Instant` on wasm32 under the hood.