### PR TITLE
feat: toggle help overlays by externally calling `PlotWidget.update(PlotUiMessage::ToggleControlsOverlay)`

### DIFF
--- a/src/plot_widget.rs
+++ b/src/plot_widget.rs
@@ -453,9 +453,7 @@ impl PlotWidget {
                 self.legend_collapsed = !self.legend_collapsed;
             }
             PlotUiMessage::ToggleControlsOverlay => {
-                if self.controls_help_enabled {
-                    self.controls_overlay_open = !self.controls_overlay_open;
-                }
+                self.controls_overlay_open = !self.controls_overlay_open;
             }
             PlotUiMessage::ToggleSeriesVisibility(id) => {
                 self.toggle_visibility(&id);
@@ -839,7 +837,7 @@ impl PlotWidget {
         has_legend: bool,
         scroll_enabled: bool,
     ) -> Option<Element<'_, PlotUiMessage>> {
-        if !self.controls_help_enabled || !self.controls_overlay_open {
+        if !self.controls_overlay_open {
             return None;
         }
 

--- a/src/plot_widget_builder.rs
+++ b/src/plot_widget_builder.rs
@@ -136,6 +136,8 @@ impl PlotWidgetBuilder {
     /// Disable the in-canvas controls/help UI (`?` button + panel).
     ///
     /// Useful if your application provides its own help UI or you want a cleaner canvas.
+    ///
+    /// When controls/help UI is disabled, you still can toggle help overlay by calling `PlotWidget.update(PlotUiMessage::ToggleControlsOverlay)`
     pub fn disable_controls_help(mut self) -> Self {
         self.disable_controls_help = true;
         self
@@ -303,7 +305,6 @@ impl PlotWidgetBuilder {
         let mut w = PlotWidget::new();
         if self.disable_controls_help {
             w.controls_help_enabled = false;
-            w.controls_overlay_open = false;
         }
         if self.disable_legend {
             w.legend_enabled = false;


### PR DESCRIPTION
I think it would be great if we could toggle help overlays via an external button.