### PR TITLE
fix: initial autoscale shouldn't update axis links

### DIFF
--- a/src/plot_state.rs
+++ b/src/plot_state.rs
@@ -247,7 +247,7 @@ impl PlotState {
         self.lines_version = self.lines_version.wrapping_add(1);
     }
 
-    pub(crate) fn autoscale(&mut self) {
+    pub(crate) fn autoscale(&mut self, update_axis_links: bool) {
         // Use user-specified limits if available, otherwise use data bounds
         let mut min_v = DVec2::new(-1.0, -1.0);
         let mut max_v = DVec2::new(1.0, 1.0);
@@ -268,7 +268,9 @@ impl PlotState {
         }
 
         self.camera.set_bounds(min_v, max_v, 0.05);
-        self.update_axis_links();
+        if update_axis_links {
+            self.update_axis_links();
+        }
     }
 
     pub(crate) fn update_ticks(
@@ -421,7 +423,7 @@ impl PlotState {
                 };
                 self.last_click_time = Some(now);
                 if double {
-                    self.autoscale();
+                    self.autoscale(true);
                     needs_redraw = true;
                 } else {
                     if self.hover_enabled && !self.pan.active && !self.selection.active {

--- a/src/plot_widget.rs
+++ b/src/plot_widget.rs
@@ -1188,8 +1188,10 @@ impl shader::Program<PlotUiMessage> for PlotWidget {
             //
             // We do so on the first update, if autoscale_on_updates is enabled, or if
             // limits have been manually set.
-            if self.autoscale_on_updates || state.data_src_version == 0 || limits_changed {
-                state.autoscale();
+            let init_axis_links = state.data_src_version == 0;
+            if self.autoscale_on_updates || init_axis_links || limits_changed {
+                // Initial autoscale shouldn't update axis links.
+                state.autoscale(!init_axis_links);
             }
 
             state.data_src_version = self.data_version;
@@ -1197,7 +1199,7 @@ impl shader::Program<PlotUiMessage> for PlotWidget {
         } else if limits_changed {
             state.x_lim = self.x_lim;
             state.y_lim = self.y_lim;
-            state.autoscale();
+            state.autoscale(true);
             effects.needs_redraw = true;
         }
 


### PR DESCRIPTION
In my case, the axis links will be overrided as other plot's initialization.

Before:

1. Change data 36's range via plot "36 vs 33"
2. Open plot "35 vs 36"
3. **Data 36's range is overrided**, which is not expected

https://github.com/user-attachments/assets/003b1f27-aef9-4eaf-806b-2662132bd3ff




Now:

https://github.com/user-attachments/assets/4a926cf0-ee3e-4dff-bc3f-f50dd2895a8f




