### PR TITLE
feat: add public current_viewport() getter + ViewportInfo

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@ pub use controls::{PanControls, PickControls, PlotControls, ZoomControls};
 pub use fill::Fill;
 pub use grid::TickWeight;
 pub use message::{DragEvent, HoverPickEvent, PlotUiMessage, PointId, TooltipContext};
-pub use plot_widget::{HighlightPoint, PlotWidget};
+pub use plot_widget::{HighlightPoint, PlotWidget, ViewportInfo};
 pub use plot_widget_builder::PlotWidgetBuilder;
 pub use point::{MarkerType, Point};
 pub use reference_lines::{HLine, VLine};

--- a/src/plot_widget.rs
+++ b/src/plot_widget.rs
@@ -50,6 +50,24 @@ pub(crate) type CursorProvider = Arc<dyn Fn(f64, f64) -> String + Send + Sync>;
 pub(crate) type HighlightPointProvider =
     Arc<dyn Fn(TooltipContext<'_>, &mut HighlightPoint) -> Option<String> + Send + Sync>;
 
+/// Current viewport state of a [`PlotWidget`].
+///
+/// Produced by [`PlotWidget::current_viewport`]. Captures the data-space
+/// ranges visible along each axis and the pixel rectangle of the plot area.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ViewportInfo {
+    /// Left edge of the visible data-space range along the x-axis.
+    pub x_min: f64,
+    /// Right edge of the visible data-space range along the x-axis.
+    pub x_max: f64,
+    /// Bottom edge of the visible data-space range along the y-axis.
+    pub y_min: f64,
+    /// Top edge of the visible data-space range along the y-axis.
+    pub y_max: f64,
+    /// Pixel rectangle of the plot-area (excludes axes, labels, legend).
+    pub plot_area: Rectangle,
+}
+
 /// A plot widget that renders data series with interactive features.
 pub struct PlotWidget {
     pub(crate) instance_id: u64,
@@ -279,6 +297,46 @@ impl PlotWidget {
     /// If set, these will override autoscaling for the y-axis.
     pub fn set_y_lim(&mut self, min: f64, max: f64) {
         self.y_lim = Some((min, max));
+    }
+
+    /// Read the current data-space viewport and plot-area pixel rectangle.
+    ///
+    /// Returns `None` before the first frame has been rendered (the widget
+    /// populates this lazily from the shader program's update phase). Once
+    /// available, the returned values track pan/zoom/resize in near real time.
+    ///
+    /// Ranges are returned in data-space coordinates: for non-linear axis
+    /// scales (e.g. `AxisScale::Log`), the internal plot-space values are
+    /// inverted back to data-space before being returned.
+    pub fn current_viewport(&self) -> Option<ViewportInfo> {
+        let (camera, bounds) = self.camera_bounds.as_ref()?;
+        let x_min_plot = camera.position.x - camera.half_extents.x;
+        let x_max_plot = camera.position.x + camera.half_extents.x;
+        let y_min_plot = camera.position.y - camera.half_extents.y;
+        let y_max_plot = camera.position.y + camera.half_extents.y;
+        let x_min = self
+            .x_axis_scale
+            .plot_to_data(x_min_plot)
+            .unwrap_or(x_min_plot);
+        let x_max = self
+            .x_axis_scale
+            .plot_to_data(x_max_plot)
+            .unwrap_or(x_max_plot);
+        let y_min = self
+            .y_axis_scale
+            .plot_to_data(y_min_plot)
+            .unwrap_or(y_min_plot);
+        let y_max = self
+            .y_axis_scale
+            .plot_to_data(y_max_plot)
+            .unwrap_or(y_max_plot);
+        Some(ViewportInfo {
+            x_min,
+            x_max,
+            y_min,
+            y_max,
+            plot_area: *bounds,
+        })
     }
 
     /// Set the y-axis scale mode.


### PR DESCRIPTION

## Motivation

Applications embedding `PlotWidget` often need to read the current viewport
programmatically to coordinate external behavior: fetching a data range from
a backend, syncing a secondary view or minimap, serializing session state,
building viewport-aware tooltips, or computing pixel-to-data projections
outside the widget's own event loop.

Today, the only way to observe viewport changes is to subscribe to
`PlotUiMessage::RenderUpdate` and read the `x_ticks` / `y_ticks` arrays —
which is indirect (tick positions approximate the viewport rather than
describe it exactly), fragile (the payload struct is `#[doc(hidden)]`),
and costly (consumers allocate a full tick vec per change). Reading on-demand
currently isn't possible at all: the relevant camera/bounds state is cached
inside `PlotWidget.camera_bounds` but is crate-private.

This PR exposes a direct, on-demand getter that returns the current data-space
ranges plus the plot area's pixel rectangle as a single `Copy` struct.

## What this PR does

- Adds `PlotWidget::current_viewport() -> Option<ViewportInfo>`.
- Adds a new public struct `ViewportInfo { x_min, x_max, y_min, y_max, plot_area: Rectangle }`.
- Re-exports `ViewportInfo` from the crate root.
- Reads from the existing cached `camera_bounds` state — no new state, no new
  syncing logic, no shader/renderer changes.
- Inverts plot-space values back to data-space through the existing
  `AxisScale::plot_to_data` so the returned ranges are meaningful even with
  `AxisScale::Log`.
- Returns `None` if the widget hasn't been rendered yet (camera_bounds is
  lazily populated during the first shader update).

## API additions

```rust
/// Current viewport state of a `PlotWidget`.
#[derive(Debug, Clone, Copy, PartialEq)]
pub struct ViewportInfo {
    pub x_min: f64,
    pub x_max: f64,
    pub y_min: f64,
    pub y_max: f64,
    pub plot_area: Rectangle,
}

impl PlotWidget {
    pub fn current_viewport(&self) -> Option<ViewportInfo> { /* ... */ }
}
```

## Non-breaking

- No existing public API is changed.
- No behavioral changes to rendering, events, or picking.
- 59 insertions, 1 deletion (lib.rs re-export line).
- No new dependencies, no new `unsafe`, no new panics.

## Example use case

```rust
use iced_plot::{PlotWidget, ViewportInfo};

fn on_tick(plot: &PlotWidget) -> Option<&'static str> {
    let vp = plot.current_viewport()?;
    // E.g.: tell a streaming backend to send the data bucket for the
    // currently-visible x range, at the right resolution for the plot width.
    let width_px = vp.plot_area.width as f64;
    request_lod(vp.x_min, vp.x_max, width_px);
    Some("requested")
}
```

## Alternatives considered

- **Subscribing to `PlotUiMessage::RenderUpdate` and reading tick positions.**
  Works, but approximate (tick values under-estimate the viewport edges),
  ties consumers to a `#[doc(hidden)]` payload struct, and doesn't support
  on-demand reads.
- **Exposing `Camera` directly.** Tighter binding to internal representation
  (e.g. `render_offset` is an implementation detail for high-precision
  rendering, not a concept the API consumer should see). The `ViewportInfo`
  shape keeps the surface minimal and stable.
- **A `ViewportChanged` message variant.** Nice additional signal but
  orthogonal to on-demand reads. Could follow as a separate PR if useful.

## Related

None.
