### PR TITLE
feat: expose AxisLink::get() and version() as public

### DIFF
--- a/src/axis_link.rs
+++ b/src/axis_link.rs
@@ -23,8 +23,22 @@ impl AxisLink {
         Default::default()
     }
 
-    /// Get the current position and half extent
-    pub(crate) fn get(&self) -> (f64, f64, u64) {
+    /// Get the current position, half-extent, and version counter.
+    ///
+    /// Returns `(center, half_extent, version)`. The data-space axis range
+    /// covered by the linked plots is `[center - half_extent, center + half_extent]`.
+    ///
+    /// The version counter is bumped on every camera change; downstream
+    /// code can poll it to detect viewport updates without plumbing the
+    /// `PlotUiMessage::RenderUpdate` stream.
+    ///
+    /// # Panics
+    ///
+    /// Panics only if the internal `RwLock` has been poisoned by a prior
+    /// panic on another thread while holding the write lock. Not expected
+    /// in normal operation.
+    #[must_use]
+    pub fn get(&self) -> (f64, f64, u64) {
         let inner = self.inner.read().unwrap();
         (inner.position, inner.half_extent, inner.version)
     }
@@ -37,8 +51,19 @@ impl AxisLink {
         inner.version = inner.version.wrapping_add(1);
     }
 
-    /// Get the current version
-    pub(crate) fn version(&self) -> u64 {
+    /// Get the current version counter.
+    ///
+    /// The counter is bumped on every camera change. A cheap way to detect
+    /// whether the viewport has moved since the last observation without
+    /// locking the value state.
+    ///
+    /// # Panics
+    ///
+    /// Panics only if the internal `RwLock` has been poisoned by a prior
+    /// panic on another thread while holding the write lock. Not expected
+    /// in normal operation.
+    #[must_use]
+    pub fn version(&self) -> u64 {
         self.inner.read().unwrap().version
     }
 }


### PR DESCRIPTION

## Motivation

`AxisLink` is already a public struct in the `iced_plot` API — users create
one with `AxisLink::new()` and pass it to `PlotWidgetBuilder::with_x_axis_link`
/ `with_y_axis_link` to synchronize pan/zoom across multiple plots. The
internal state (center position, half-extent, version counter) is updated
on every camera change via the `update_axis_links` path.

However, the two reader methods — `get()` and `version()` — are currently
`pub(crate)`, meaning downstream code can *create* and *attach* an
`AxisLink` but cannot *observe* the state it carries. This limits the link
to same-crate synchronization only.

Exposing these readers lets downstream code do three useful things without
any additional state or plumbing:

1. **Cheap viewport-change detection** by polling `version()` (bumped on every
   camera change) — avoids subscribing to `PlotUiMessage::RenderUpdate`
   just to know whether the viewport moved.
2. **Cross-application synchronization**, e.g. syncing a secondary view
   (minimap, orderbook ladder, correlated chart) by reading the linked
   position/half-extent directly.
3. **Viewport serialization** for session state, where knowing the last
   center+extent is sufficient to restore the view.

## What this PR does

- Changes visibility of `AxisLink::get(&self) -> (f64, f64, u64)` from
  `pub(crate)` to `pub`.
- Changes visibility of `AxisLink::version(&self) -> u64` from
  `pub(crate)` to `pub`.
- Adds `#[must_use]` attributes and `# Panics` doc sections to the newly-public
  methods, keeping the crate clippy::pedantic clean.
- Improves the doc comment on `get()` to document the return-tuple semantics
  and the version-counter use case.

## API additions

```rust
impl AxisLink {
    /// Returns `(center, half_extent, version)`.
    #[must_use]
    pub fn get(&self) -> (f64, f64, u64) { /* ... */ }

    /// Returns the current version counter (bumped on every camera change).
    #[must_use]
    pub fn version(&self) -> u64 { /* ... */ }
}
```

## Non-breaking

- No existing public API is changed — only made more accessible.
- No behavioral changes.
- 29 insertions, 4 deletions (mostly doc additions; 2 lines of visibility
  modifier changes).
- Both methods are pure readers over an `Arc<RwLock<_>>` already internal
  to a public struct. Exposing them adds no new invariants and no new
  thread-safety concerns beyond those already implied by `AxisLink`
  being `Clone + Send + Sync`.

## Example use case

```rust
use iced_plot::AxisLink;

struct App {
    x_link: AxisLink,
    last_version: u64,
}

impl App {
    fn poll_viewport_change(&mut self) {
        let v = self.x_link.version();
        if v != self.last_version {
            let (center, half_extent, _) = self.x_link.get();
            let (x_min, x_max) = (center - half_extent, center + half_extent);
            self.on_viewport_changed(x_min, x_max);
            self.last_version = v;
        }
    }
}
```

## Alternatives considered

- **Leaving `AxisLink` crate-private and adding a different getter on
  `PlotWidget`.** Works, but duplicates state: the link already carries
  the data; exposing its readers is the minimal change.
- **Adding a dedicated `ViewportChanged` message variant.** Useful
  complement but orthogonal; this PR is the cheapest path to polling-based
  change detection.
- **Making the internal fields `pub`.** Would leak the `Arc<RwLock<_>>`
  structure, discouraging future changes to the locking strategy.
  Keeping the method surface means the implementation can evolve.

## Related

None.
