### PR TITLE
feat: add public plot_area_bounds() getter

### DIFF
--- a/src/plot_widget.rs
+++ b/src/plot_widget.rs
@@ -281,6 +281,16 @@ impl PlotWidget {
         self.y_lim = Some((min, max));
     }
 
+    /// Pixel rectangle of the plot area (excluding axes, labels, legend).
+    ///
+    /// Returns `None` before the first frame has been rendered. Useful for
+    /// pixel-aware downsampling requests against a streaming data source
+    /// when only the pixel dimensions are needed.
+    #[must_use]
+    pub fn plot_area_bounds(&self) -> Option<Rectangle> {
+        self.camera_bounds.as_ref().map(|(_, r)| *r)
+    }
+
     /// Set the y-axis scale mode.
     ///
     /// This does not modify tick producer/formatter settings.


### PR DESCRIPTION

## Motivation

Applications embedding `PlotWidget` sometimes need the current pixel
rectangle of the plot area (excluding axes, labels, legend) but don't need
the data-space ranges. Common cases:

- Choosing an **LOD level** when requesting downsampled data from a streaming
  source: the right bucket resolution depends on how many pixels each
  bucket will cover.
- Laying out **overlay UI** relative to the plot area (status badges,
  drawing tools, floating annotations placed in world coordinates but
  clipped to the plot box).
- Computing **hit-test regions** for custom interaction widgets layered
  on top of the plot via `iced::widget::stack!`.

Today, the plot area rectangle is cached on `PlotWidget` as part of
`camera_bounds`, but that field is crate-private; `RenderUpdate` also
carries the bounds in its `camera_bounds` payload, but that payload is
`pub(crate)` behind a `#[doc(hidden)]` struct. So even though the data is
already tracked and updated on every pan/zoom/resize, there is no
public way to read it.

This PR exposes the minimum-viable getter for that case: a one-liner
that returns `Option<Rectangle>`.

## What this PR does

- Adds `PlotWidget::plot_area_bounds(&self) -> Option<Rectangle>`.
- Reads from the existing cached `camera_bounds` state — no new state,
  no new tracking logic.
- Returns `None` if the widget hasn't been rendered yet (camera_bounds is
  lazily populated during the first shader update).

## API additions

```rust
impl PlotWidget {
    /// Pixel rectangle of the plot area (excluding axes, labels, legend).
    /// Returns `None` before the first frame has been rendered.
    #[must_use]
    pub fn plot_area_bounds(&self) -> Option<Rectangle> { /* ... */ }
}
```

## Non-breaking

- No existing public API is changed.
- No behavioral changes.
- 10 insertions, 0 deletions.
- Single file, single method.

## Example use case

```rust
use iced::window;
use iced_plot::PlotWidget;

fn choose_lod_bucket(plot: &PlotWidget, visible_x_range: (f64, f64)) -> f64 {
    let (x_min, x_max) = visible_x_range;
    let Some(area) = plot.plot_area_bounds() else {
        return (x_max - x_min) / 100.0; // fallback
    };
    let px = area.width as f64;
    // one data bucket per pixel
    (x_max - x_min) / px.max(1.0)
}
```

## Alternatives considered

- **Returning the rectangle only through the richer `current_viewport()`
  getter** (proposed in a separate PR). Viable, but callers that only
  care about pixel dimensions shouldn't have to allocate/cover a full
  `ViewportInfo` or invert axis scales that they don't use.
- **Returning `Option<(f32, f32)>` for just width+height.** Loses
  absolute position, which overlay UIs need.

## Related

None. Complementary to any viewport-exposure PR, but independent —
applications that only need pixel dimensions can use this alone.
