### PR TITLE
feat: series-level pickable gate

### DIFF
--- a/examples/auto_backend.rs
+++ b/examples/auto_backend.rs
@@ -196,7 +196,8 @@ fn new_plot() -> PlotWidget {
         })
         .collect();
     let s2 = Series::markers_only(positions, MarkerStyle::circle(6.0))
-        .with_label("cosine_markers_only")
+        .with_label("cosine_markers_only (not pickable)")
+        .with_pickable(false)
         .with_color(Color::from_rgb(0.9, 0.3, 0.3));
 
     let positions = (0..30)

--- a/examples/line_only.rs
+++ b/examples/line_only.rs
@@ -70,7 +70,8 @@ fn new() -> PlotWidget {
         })
         .collect();
     let s2 = Series::markers_only(positions, MarkerStyle::circle(6.0))
-        .with_label("cosine_markers_only")
+        .with_label("cosine_markers_only (not pickable)")
+        .with_pickable(false)
         .with_color(Color::from_rgb(0.9, 0.3, 0.3));
 
     let positions = (0..30)

--- a/src/picking.rs
+++ b/src/picking.rs
@@ -209,6 +209,9 @@ fn cpu_pick_hit(
         if span_idx >= series.len() {
             break;
         }
+        if !series[span_idx].pickable {
+            continue;
+        }
 
         let world = marker_center_world(pt);
         let ndc_x = (world.x - camera.position.x) / camera.half_extents.x;
@@ -681,7 +684,8 @@ impl PickingPass {
                 entry_point: Some("vs_main"),
                 compilation_options: PipelineCompilationOptions::default(),
                 buffers: &[VertexBufferLayout {
-                    // Must match markers: 36 bytes per instance
+                    // Must match markers: 36 bytes per instance.
+                    // Location 4 packs size_mode in bit 0 and pickable in bit 1.
                     array_stride: 36,
                     step_mode: VertexStepMode::Instance,
                     attributes: &[
@@ -762,6 +766,9 @@ impl PickingPass {
         }
 
         let span: &SeriesSpan = &series[span_idx];
+        if !span.pickable {
+            return None;
+        }
         if local_idx >= span.point_indices.len() {
             return None;
         }
@@ -772,5 +779,73 @@ impl PickingPass {
             series_id: span.id,
             point_index,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use glam::{DVec2, Vec2};
+    use iced::Rectangle;
+
+    use super::cpu_pick_hit;
+    use crate::{
+        Color, LineStyle, Point, PointId, ShapeId, camera::Camera, plot_state::SeriesSpan,
+    };
+
+    #[test]
+    fn cpu_pick_skips_unpickable_series() {
+        let points = [Point::new(0.0, 0.0, 6.0), Point::new(0.1, 0.0, 6.0)];
+        let series = [
+            SeriesSpan {
+                id: ShapeId(1),
+                start: 0,
+                len: 1,
+                point_indices: Arc::from([0usize]),
+                line_style: Some(LineStyle::solid()),
+                color: Color::BLACK,
+                marker: 0,
+                pickable: false,
+            },
+            SeriesSpan {
+                id: ShapeId(2),
+                start: 1,
+                len: 1,
+                point_indices: Arc::from([0usize]),
+                line_style: Some(LineStyle::solid()),
+                color: Color::BLACK,
+                marker: 0,
+                pickable: true,
+            },
+        ];
+        let camera = Camera {
+            position: DVec2::ZERO,
+            half_extents: DVec2::ONE,
+            render_offset: DVec2::ZERO,
+        };
+        let bounds = Rectangle {
+            x: 0.0,
+            y: 0.0,
+            width: 100.0,
+            height: 100.0,
+        };
+
+        let hit = cpu_pick_hit(
+            &points,
+            &series,
+            &camera,
+            &bounds,
+            Vec2::new(50.0, 50.0),
+            8.0,
+        );
+
+        assert_eq!(
+            hit,
+            Some(PointId {
+                series_id: ShapeId(2),
+                point_index: 0,
+            })
+        );
     }
 }

--- a/src/plot_renderer/shader.rs
+++ b/src/plot_renderer/shader.rs
@@ -445,7 +445,7 @@ impl PlotRenderer {
                 compilation_options: PipelineCompilationOptions::default(),
                 buffers: &[VertexBufferLayout {
                     // Explicit 36-byte stride: vec2<f32> position (8) + vec4<f32> color (16)
-                    // + u32 marker (4) + f32 size (4) + u32 size_mode (4) = 36
+                    // + u32 marker (4) + f32 size (4) + u32 size_mode/pickable flags (4) = 36
                     array_stride: 36u64,
                     step_mode: VertexStepMode::Instance,
                     attributes: &[
@@ -839,7 +839,7 @@ impl PlotRenderer {
                 writer.write_color(color);
                 writer.write_u32(s.marker);
                 writer.write_f32(p.size);
-                writer.write_u32(p.size_mode);
+                writer.write_u32(crate::point::marker_flags(p.size_mode, s.pickable));
 
                 let original_idx = s.point_indices.get(local_i).copied().unwrap_or(local_i);
                 id_map.push((span_idx as u32, original_idx as u32));
@@ -1223,7 +1223,7 @@ impl PlotRenderer {
                 marker_writer.write_color(&highlight_point.color);
                 marker_writer.write_u32(marker_style.marker_type as u32);
                 marker_writer.write_f32(size);
-                marker_writer.write_u32(size_mode);
+                marker_writer.write_u32(crate::point::marker_flags(size_mode, true));
             }
         }
 

--- a/src/plot_state.rs
+++ b/src/plot_state.rs
@@ -217,6 +217,7 @@ impl PlotState {
                 line_style: series.line_style,
                 color,
                 marker,
+                pickable: series.pickable,
             });
 
             // If this series has a world-space marker, the data_max should be adjusted to account for the marker size.
@@ -975,6 +976,7 @@ pub(crate) struct SeriesSpan {
     pub(crate) line_style: Option<LineStyle>,
     pub(crate) color: Color,
     pub(crate) marker: u32,
+    pub(crate) pickable: bool,
 }
 
 #[derive(Default, Debug, Clone)]

--- a/src/plot_widget.rs
+++ b/src/plot_widget.rs
@@ -1655,7 +1655,7 @@ impl PlotWidget {
     fn valid_point_id(&self, point_id: &PointId) -> bool {
         self.series
             .get(&point_id.series_id)
-            .map(|series| point_id.point_index < series.positions.len())
+            .map(|series| series.pickable && point_id.point_index < series.positions.len())
             .unwrap_or(false)
     }
 }

--- a/src/point.rs
+++ b/src/point.rs
@@ -18,6 +18,12 @@ pub enum MarkerType {
 
 pub(crate) const MARKER_SIZE_PIXELS: u32 = 0;
 pub(crate) const MARKER_SIZE_WORLD: u32 = 1;
+pub(crate) const MARKER_SIZE_MODE_MASK: u32 = 0b1;
+pub(crate) const MARKER_PICKABLE_BIT: u32 = 0b10;
+
+pub(crate) fn marker_flags(size_mode: u32, pickable: bool) -> u32 {
+    (size_mode & MARKER_SIZE_MODE_MASK) | if pickable { MARKER_PICKABLE_BIT } else { 0 }
+}
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]

--- a/src/series.rs
+++ b/src/series.rs
@@ -304,6 +304,9 @@ pub struct Series {
 
     /// Line style for connecting markers. If None, no line is drawn.
     pub line_style: Option<LineStyle>,
+
+    /// Can be hovered or picked. Defaults to `true`.
+    pub pickable: bool,
 }
 
 impl Series {
@@ -317,6 +320,7 @@ impl Series {
             color: Color::from_rgb(0.3, 0.3, 0.9),
             marker_style: Some(marker_style),
             line_style: Some(line_style),
+            pickable: true,
         }
     }
 
@@ -330,6 +334,7 @@ impl Series {
             color: Color::from_rgb(0.3, 0.3, 0.9),
             marker_style: None,
             line_style: Some(line_style),
+            pickable: true,
         }
     }
 
@@ -343,6 +348,7 @@ impl Series {
             color: Color::from_rgb(0.3, 0.3, 0.9),
             marker_style: Some(marker_style),
             line_style: None,
+            pickable: true,
         }
     }
 
@@ -390,6 +396,12 @@ impl Series {
     /// Set per-point colors for the series. Length must match the number of positions.
     pub fn with_point_colors(mut self, colors: Vec<Color>) -> Self {
         self.point_colors = Some(colors);
+        self
+    }
+
+    /// Enable or disable interactive hover/pick behavior for this series.
+    pub fn with_pickable(mut self, pickable: bool) -> Self {
+        self.pickable = pickable;
         self
     }
 

--- a/src/shaders/markers.wgsl
+++ b/src/shaders/markers.wgsl
@@ -9,6 +9,8 @@ const CIRCLE_RADIUS: f32 = 1.0;
 const EMPTY_CIRCLE_INNER: f32 = 0.7;
 const STAR_ANGLE_MULT: f32 = 5.0;
 const STAR_INNER_SCALE: f32 = 0.3;
+const MARKER_SIZE_MODE_MASK: u32 = 1u;
+const MARKER_SIZE_WORLD: u32 = 1u;
 
 struct CameraUniform {
     view_proj: mat4x4<f32>,
@@ -24,7 +26,7 @@ struct VertexInput {
     @location(1) color: vec4<f32>,
     @location(2) marker_type: u32,
     @location(3) size: f32,
-    @location(4) size_mode: u32,
+    @location(4) marker_flags: u32,
 };
 
 struct VertexOutput {
@@ -44,10 +46,11 @@ fn vs_main(
 
     // Generate quad vertices for each marker
     let local_pos = QUAD_POS[vertex_index];
+    let size_mode = model.marker_flags & MARKER_SIZE_MODE_MASK;
 
     var center_pos = model.position;
     var half_world = 0.0;
-    if (model.size_mode == 1u) {
+    if (size_mode == MARKER_SIZE_WORLD) {
         half_world = model.size * 0.5;
         center_pos = center_pos + vec2<f32>(half_world, half_world);
     }
@@ -57,7 +60,7 @@ fn vs_main(
     // Interpret model.size as pixels or world units depending on size_mode
     var half_size_px_x = model.size;
     var half_size_px_y = model.size;
-    if (model.size_mode == 1u) {
+    if (size_mode == MARKER_SIZE_WORLD) {
         half_size_px_x = half_world / camera.pixel_to_world.x;
         half_size_px_y = half_world / camera.pixel_to_world.y;
     }

--- a/src/shaders/pick_markers.wgsl
+++ b/src/shaders/pick_markers.wgsl
@@ -6,6 +6,9 @@ const QUAD_POS: array<vec2<f32>, 4> = array<vec2<f32>, 4>(
     vec2<f32>(-1.0, 1.0),   // top-left
     vec2<f32>(1.0, 1.0),    // top-right
 );
+const MARKER_SIZE_MODE_MASK: u32 = 1u;
+const MARKER_SIZE_WORLD: u32 = 1u;
+const MARKER_PICKABLE_BIT: u32 = 2u;
 
 struct CameraUniform {
     view_proj: mat4x4<f32>,
@@ -21,13 +24,14 @@ struct VertexInput {
     @location(1) color: vec4<f32>,
     // We don't care about the marker type which is at location 2.
     @location(3) size: f32,
-    @location(4) size_mode: u32,
+    @location(4) marker_flags: u32,
 };
 
 struct VsOut {
     @builtin(position) clip_position: vec4<f32>,
     @location(0) local_pos: vec2<f32>,
     @interpolate(flat) @location(1) instance_id: u32,
+    @interpolate(flat) @location(2) pickable: u32,
 };
 
 @vertex
@@ -38,16 +42,17 @@ fn vs_main(
 ) -> VsOut {
     var out: VsOut;
     let local = QUAD_POS[vid];
+    let size_mode = model.marker_flags & MARKER_SIZE_MODE_MASK;
     var center_pos = model.position;
     var half_world = 0.0;
-    if (model.size_mode == 1u) {
+    if (size_mode == MARKER_SIZE_WORLD) {
         half_world = model.size * 0.5;
         center_pos = center_pos + vec2<f32>(half_world, half_world);
     }
     let center = camera.view_proj * vec4<f32>(center_pos, 0.0, 1.0);
     var half_size_px_x = model.size;
     var half_size_px_y = model.size;
-    if (model.size_mode == 1u) {
+    if (size_mode == MARKER_SIZE_WORLD) {
         half_size_px_x = half_world / camera.pixel_to_world.x;
         half_size_px_y = half_world / camera.pixel_to_world.y;
     }
@@ -58,11 +63,15 @@ fn vs_main(
     out.clip_position = center + offset;
     out.local_pos = local;
     out.instance_id = iid;
+    out.pickable = model.marker_flags & MARKER_PICKABLE_BIT;
     return out;
 }
 
 @fragment
 fn fs_main(in: VsOut) -> @location(0) u32 {
+    if (in.pickable == 0u) {
+        discard;
+    }
     if length(in.local_pos) <= 1.0 {     
         // 1-based id so 0 means background
         return in.instance_id + 1u;


### PR DESCRIPTION
I add a series-level `pickable` gate so callers can opt individual series out of hover and click picking while keeping them rendered normally. The new `Series::with_pickable(false)` API defaults to the existing pickable behavior, and both CPU and GPU picking paths honor the flag before producing hover/pick events.

The marker instance data keeps the existing 36-byte layout by packing `pickable` into the same `u32` as `size_mode`: bit 0 stores the size mode and bit 1 stores whether the marker participates in picking. This lets the pick shader discard unpickable markers without adding another vertex attribute.

Key changes:
- Add `Series::pickable` and `Series::with_pickable`
- Propagate the flag through `SeriesSpan` and point-id validation
- Skip unpickable series in CPU picking and GPU pick shader output
- Pack marker `size_mode` and `pickable` into one `marker_flags` value
- Update examples to demonstrate a non-pickable marker-only series
- Add a regression test for CPU picking behavior