### PR TITLE
refactor: generalize plot controls with trigger-action bindings

### DIFF
--- a/examples/controls_toggles.rs
+++ b/examples/controls_toggles.rs
@@ -83,104 +83,70 @@ impl App {
 
     fn set_drag(&mut self, button: mouse::Button, action: DragAction, enabled: bool) {
         if enabled {
-            self.widget
-                .get_controls_mut()
-                .interaction
-                .bind_drag(button, action);
+            self.widget.get_controls_mut().bind_drag(button, action);
         } else {
-            self.widget
-                .get_controls_mut()
-                .interaction
-                .unbind_drag(button);
+            self.widget.get_controls_mut().unbind_drag(button);
         }
     }
 
     fn drag_enabled(&self, button: mouse::Button, action: DragAction) -> bool {
-        self.widget
-            .get_controls()
-            .interaction
-            .drag_is_bound(button, action)
+        self.widget.get_controls().drag_is_bound(button, action)
     }
 
     fn set_scroll(&mut self, modifiers: keyboard::Modifiers, action: ScrollAction, enabled: bool) {
         if enabled {
             self.widget
                 .get_controls_mut()
-                .interaction
                 .bind_scroll(modifiers, action);
         } else {
-            self.widget
-                .get_controls_mut()
-                .interaction
-                .unbind_scroll(modifiers);
+            self.widget.get_controls_mut().unbind_scroll(modifiers);
         }
     }
 
     fn scroll_enabled(&self, modifiers: keyboard::Modifiers, action: ScrollAction) -> bool {
         self.widget
             .get_controls()
-            .interaction
             .scroll_is_bound(modifiers, action)
     }
 
     fn set_click(&mut self, button: mouse::Button, action: ClickAction, enabled: bool) {
         if enabled {
-            self.widget
-                .get_controls_mut()
-                .interaction
-                .bind_click(button, action);
+            self.widget.get_controls_mut().bind_click(button, action);
         } else {
-            self.widget
-                .get_controls_mut()
-                .interaction
-                .unbind_click(button);
+            self.widget.get_controls_mut().unbind_click(button);
         }
     }
 
     fn click_enabled(&self, button: mouse::Button, action: ClickAction) -> bool {
-        self.widget
-            .get_controls()
-            .interaction
-            .click_is_bound(button, action)
+        self.widget.get_controls().click_is_bound(button, action)
     }
 
     fn set_double_click(&mut self, button: mouse::Button, action: ClickAction, enabled: bool) {
         if enabled {
             self.widget
                 .get_controls_mut()
-                .interaction
                 .bind_double_click(button, action);
         } else {
-            self.widget
-                .get_controls_mut()
-                .interaction
-                .unbind_double_click(button);
+            self.widget.get_controls_mut().unbind_double_click(button);
         }
     }
 
     fn double_click_enabled(&self, button: mouse::Button, action: ClickAction) -> bool {
         self.widget
             .get_controls()
-            .interaction
             .double_click_is_bound(button, action)
     }
 
     fn set_key(&mut self, key: keyboard::Key, action: KeyAction, enabled: bool) {
         if enabled {
-            self.widget
-                .get_controls_mut()
-                .interaction
-                .bind_key(key, action);
+            self.widget.get_controls_mut().bind_key(key, action);
         } else {
-            self.widget.get_controls_mut().interaction.unbind_key(&key);
+            self.widget.get_controls_mut().unbind_key(&key);
         }
     }
 
     fn key_enabled(&self, key: &keyboard::Key, action: KeyAction) -> bool {
-        self.widget
-            .get_controls()
-            .interaction
-            .key_is_bound(key, action)
+        self.widget.get_controls().key_is_bound(key, action)
     }
 
     fn update(&mut self, message: Message) {
@@ -190,23 +156,17 @@ impl App {
                 self.set_scroll(keyboard::Modifiers::NONE, ScrollAction::Pan, enabled);
             }
             Message::ToggleDragToPan(enabled) => {
-                self.set_drag(mouse::Button::Right, DragAction::Pan, enabled);
+                self.set_drag(mouse::Button::Left, DragAction::Pan, enabled);
             }
             Message::ToggleArrowsToPan(enabled) => {
                 if enabled {
-                    self.widget
-                        .get_controls_mut()
-                        .interaction
-                        .bind_arrow_pan(0.1);
+                    self.widget.get_controls_mut().bind_arrow_pan(0.1);
                 } else {
-                    self.widget
-                        .get_controls_mut()
-                        .interaction
-                        .unbind_arrow_pan();
+                    self.widget.get_controls_mut().unbind_arrow_pan();
                 }
             }
             Message::ToggleBoxZoom(enabled) => {
-                self.set_drag(mouse::Button::Left, DragAction::BoxZoom, enabled);
+                self.set_drag(mouse::Button::Right, DragAction::BoxZoom, enabled);
             }
             Message::ToggleCtrlScrollZoom(enabled) => {
                 self.set_scroll(keyboard::Modifiers::CTRL, ScrollAction::Zoom, enabled);
@@ -232,10 +192,10 @@ impl App {
                 );
             }
             Message::ToggleHighlightOnHover(enabled) => {
-                self.widget.get_controls_mut().highlight_on_hover = enabled;
+                self.widget.set_highlight_on_hover(enabled);
             }
             Message::ToggleShowControlsHelp(enabled) => {
-                self.widget.get_controls_mut().show_controls_help = enabled;
+                self.widget.set_controls_help(enabled);
             }
         }
     }
@@ -252,14 +212,9 @@ impl App {
                     checkbox(self.drag_enabled(mouse::Button::Left, DragAction::Pan))
                         .label("drag")
                         .on_toggle(Message::ToggleDragToPan),
-                    checkbox(
-                        self.widget
-                            .get_controls()
-                            .interaction
-                            .arrows_to_pan_enabled()
-                    )
-                    .label("arrows")
-                    .on_toggle(Message::ToggleArrowsToPan),
+                    checkbox(self.widget.get_controls().arrows_to_pan_enabled())
+                        .label("arrows")
+                        .on_toggle(Message::ToggleArrowsToPan),
                 ]
                 .spacing(16),
                 row![
@@ -299,10 +254,10 @@ impl App {
                 ]
                 .spacing(16),
                 row![
-                    checkbox(self.widget.get_controls().highlight_on_hover)
+                    checkbox(self.widget.highlight_on_hover())
                         .label("Highlight on hover")
                         .on_toggle(Message::ToggleHighlightOnHover),
-                    checkbox(self.widget.get_controls().show_controls_help)
+                    checkbox(self.widget.controls_help_enabled())
                         .label("Show controls help")
                         .on_toggle(Message::ToggleShowControlsHelp),
                 ]

--- a/examples/controls_toggles.rs
+++ b/examples/controls_toggles.rs
@@ -1,11 +1,11 @@
 //! Demonstrates toggling plot interaction controls at runtime.
 use iced::{
-    Element, Length,
+    Element, Length, keyboard, mouse,
     widget::{checkbox, column, container, row, text},
 };
 use iced_plot::{
-    Color, LineStyle, MarkerStyle, PlotControls, PlotUiMessage, PlotWidget, PlotWidgetBuilder,
-    Series,
+    ClickAction, Color, DragAction, KeyAction, LineStyle, MarkerStyle, PlotUiMessage, PlotWidget,
+    PlotWidgetBuilder, ScrollAction, Series,
 };
 
 fn main() -> iced::Result {
@@ -20,9 +20,11 @@ enum Message {
     Plot(PlotUiMessage),
     ToggleScrollToPan(bool),
     ToggleDragToPan(bool),
+    ToggleArrowsToPan(bool),
     ToggleBoxZoom(bool),
     ToggleCtrlScrollZoom(bool),
     ToggleDoubleClickAutoscale(bool),
+    ToggleKeyAutoscale(bool),
     ToggleClickToPick(bool),
     ToggleClearPickOnEscape(bool),
     ToggleHighlightOnHover(bool),
@@ -31,13 +33,10 @@ enum Message {
 
 struct App {
     widget: PlotWidget,
-    controls: PlotControls,
 }
 
 impl App {
     fn new() -> Self {
-        let controls = PlotControls::default();
-
         let line = Series::line_only(
             (0..240)
                 .map(|i| {
@@ -63,7 +62,6 @@ impl App {
         .with_color(Color::from_rgb(1.0, 0.5, 0.35));
 
         let widget = PlotWidgetBuilder::new()
-            .with_controls(controls)
             .with_x_label("x")
             .with_y_label("y")
             .with_crosshairs(true)
@@ -80,52 +78,164 @@ impl App {
             .add_series(markers)
             .build()
             .unwrap();
-
-        Self { widget, controls }
+        Self { widget }
     }
 
-    fn apply_controls(&mut self) {
-        self.widget.set_controls(self.controls);
+    fn set_drag(&mut self, button: mouse::Button, action: DragAction, enabled: bool) {
+        if enabled {
+            self.widget
+                .get_controls_mut()
+                .interaction
+                .bind_drag(button, action);
+        } else {
+            self.widget
+                .get_controls_mut()
+                .interaction
+                .unbind_drag(button);
+        }
+    }
+
+    fn drag_enabled(&self, button: mouse::Button, action: DragAction) -> bool {
+        self.widget
+            .get_controls()
+            .interaction
+            .drag_is_bound(button, action)
+    }
+
+    fn set_scroll(&mut self, modifiers: keyboard::Modifiers, action: ScrollAction, enabled: bool) {
+        if enabled {
+            self.widget
+                .get_controls_mut()
+                .interaction
+                .bind_scroll(modifiers, action);
+        } else {
+            self.widget
+                .get_controls_mut()
+                .interaction
+                .unbind_scroll(modifiers);
+        }
+    }
+
+    fn scroll_enabled(&self, modifiers: keyboard::Modifiers, action: ScrollAction) -> bool {
+        self.widget
+            .get_controls()
+            .interaction
+            .scroll_is_bound(modifiers, action)
+    }
+
+    fn set_click(&mut self, button: mouse::Button, action: ClickAction, enabled: bool) {
+        if enabled {
+            self.widget
+                .get_controls_mut()
+                .interaction
+                .bind_click(button, action);
+        } else {
+            self.widget
+                .get_controls_mut()
+                .interaction
+                .unbind_click(button);
+        }
+    }
+
+    fn click_enabled(&self, button: mouse::Button, action: ClickAction) -> bool {
+        self.widget
+            .get_controls()
+            .interaction
+            .click_is_bound(button, action)
+    }
+
+    fn set_double_click(&mut self, button: mouse::Button, action: ClickAction, enabled: bool) {
+        if enabled {
+            self.widget
+                .get_controls_mut()
+                .interaction
+                .bind_double_click(button, action);
+        } else {
+            self.widget
+                .get_controls_mut()
+                .interaction
+                .unbind_double_click(button);
+        }
+    }
+
+    fn double_click_enabled(&self, button: mouse::Button, action: ClickAction) -> bool {
+        self.widget
+            .get_controls()
+            .interaction
+            .double_click_is_bound(button, action)
+    }
+
+    fn set_key(&mut self, key: keyboard::Key, action: KeyAction, enabled: bool) {
+        if enabled {
+            self.widget
+                .get_controls_mut()
+                .interaction
+                .bind_key(key, action);
+        } else {
+            self.widget.get_controls_mut().interaction.unbind_key(&key);
+        }
+    }
+
+    fn key_enabled(&self, key: &keyboard::Key, action: KeyAction) -> bool {
+        self.widget
+            .get_controls()
+            .interaction
+            .key_is_bound(key, action)
     }
 
     fn update(&mut self, message: Message) {
         match message {
             Message::Plot(msg) => self.widget.update(msg),
             Message::ToggleScrollToPan(enabled) => {
-                self.controls.pan.scroll_to_pan = enabled;
-                self.apply_controls();
+                self.set_scroll(keyboard::Modifiers::NONE, ScrollAction::Pan, enabled);
             }
             Message::ToggleDragToPan(enabled) => {
-                self.controls.pan.drag_to_pan = enabled;
-                self.apply_controls();
+                self.set_drag(mouse::Button::Right, DragAction::Pan, enabled);
+            }
+            Message::ToggleArrowsToPan(enabled) => {
+                if enabled {
+                    self.widget
+                        .get_controls_mut()
+                        .interaction
+                        .bind_arrow_pan(0.1);
+                } else {
+                    self.widget
+                        .get_controls_mut()
+                        .interaction
+                        .unbind_arrow_pan();
+                }
             }
             Message::ToggleBoxZoom(enabled) => {
-                self.controls.zoom.box_zoom = enabled;
-                self.apply_controls();
+                self.set_drag(mouse::Button::Left, DragAction::BoxZoom, enabled);
             }
             Message::ToggleCtrlScrollZoom(enabled) => {
-                self.controls.zoom.scroll_with_ctrl = enabled;
-                self.apply_controls();
+                self.set_scroll(keyboard::Modifiers::CTRL, ScrollAction::Zoom, enabled);
             }
             Message::ToggleDoubleClickAutoscale(enabled) => {
-                self.controls.zoom.double_click_autoscale = enabled;
-                self.apply_controls();
+                self.set_double_click(mouse::Button::Left, ClickAction::Autoscale, enabled);
+            }
+            Message::ToggleKeyAutoscale(enabled) => {
+                self.set_key(
+                    keyboard::Key::Character("f".into()),
+                    KeyAction::Autoscale,
+                    enabled,
+                );
             }
             Message::ToggleClickToPick(enabled) => {
-                self.controls.pick.click_to_pick = enabled;
-                self.apply_controls();
+                self.set_click(mouse::Button::Left, ClickAction::Pick, enabled);
             }
             Message::ToggleClearPickOnEscape(enabled) => {
-                self.controls.pick.clear_on_escape = enabled;
-                self.apply_controls();
+                self.set_key(
+                    keyboard::Key::Named(keyboard::key::Named::Escape),
+                    KeyAction::ClearPick,
+                    enabled,
+                );
             }
             Message::ToggleHighlightOnHover(enabled) => {
-                self.controls.highlight_on_hover = enabled;
-                self.apply_controls();
+                self.widget.get_controls_mut().highlight_on_hover = enabled;
             }
             Message::ToggleShowControlsHelp(enabled) => {
-                self.controls.show_controls_help = enabled;
-                self.apply_controls();
+                self.widget.get_controls_mut().show_controls_help = enabled;
             }
         }
     }
@@ -135,40 +245,64 @@ impl App {
             column![
                 text("Plot controls").size(18),
                 row![
-                    checkbox(self.controls.pan.scroll_to_pan)
-                        .label("Pan: scroll")
+                    text("Pan:"),
+                    checkbox(self.scroll_enabled(keyboard::Modifiers::NONE, ScrollAction::Pan))
+                        .label("scroll")
                         .on_toggle(Message::ToggleScrollToPan),
-                    checkbox(self.controls.pan.drag_to_pan)
-                        .label("Pan: drag")
+                    checkbox(self.drag_enabled(mouse::Button::Left, DragAction::Pan))
+                        .label("drag")
                         .on_toggle(Message::ToggleDragToPan),
+                    checkbox(
+                        self.widget
+                            .get_controls()
+                            .interaction
+                            .arrows_to_pan_enabled()
+                    )
+                    .label("arrows")
+                    .on_toggle(Message::ToggleArrowsToPan),
                 ]
                 .spacing(16),
                 row![
-                    checkbox(self.controls.zoom.box_zoom)
-                        .label("Zoom: box zoom with right-drag")
+                    text("Zoom:"),
+                    checkbox(self.drag_enabled(mouse::Button::Right, DragAction::BoxZoom))
+                        .label("box zoom with right-drag")
                         .on_toggle(Message::ToggleBoxZoom),
-                    checkbox(self.controls.zoom.scroll_with_ctrl)
-                        .label("Zoom: Ctrl+scroll")
+                    checkbox(self.scroll_enabled(keyboard::Modifiers::CTRL, ScrollAction::Zoom))
+                        .label("Ctrl+scroll")
                         .on_toggle(Message::ToggleCtrlScrollZoom),
-                    checkbox(self.controls.zoom.double_click_autoscale)
-                        .label("Zoom: double-click autoscale")
-                        .on_toggle(Message::ToggleDoubleClickAutoscale),
+                    checkbox(
+                        self.double_click_enabled(mouse::Button::Left, ClickAction::Autoscale)
+                    )
+                    .label("double-click autoscale")
+                    .on_toggle(Message::ToggleDoubleClickAutoscale),
+                    checkbox(
+                        self.key_enabled(
+                            &keyboard::Key::Character("f".into()),
+                            KeyAction::Autoscale,
+                        )
+                    )
+                    .label("key \"f\" to autoscale")
+                    .on_toggle(Message::ToggleKeyAutoscale),
                 ]
                 .spacing(16),
                 row![
-                    checkbox(self.controls.pick.click_to_pick)
-                        .label("Pick: click to pick")
+                    text("Pick:"),
+                    checkbox(self.click_enabled(mouse::Button::Left, ClickAction::Pick))
+                        .label("click to pick")
                         .on_toggle(Message::ToggleClickToPick),
-                    checkbox(self.controls.pick.clear_on_escape)
-                        .label("Pick: Esc clears")
-                        .on_toggle(Message::ToggleClearPickOnEscape),
+                    checkbox(self.key_enabled(
+                        &keyboard::Key::Named(keyboard::key::Named::Escape),
+                        KeyAction::ClearPick,
+                    ))
+                    .label("Esc clears")
+                    .on_toggle(Message::ToggleClearPickOnEscape),
                 ]
                 .spacing(16),
                 row![
-                    checkbox(self.controls.highlight_on_hover)
+                    checkbox(self.widget.get_controls().highlight_on_hover)
                         .label("Highlight on hover")
                         .on_toggle(Message::ToggleHighlightOnHover),
-                    checkbox(self.controls.show_controls_help)
+                    checkbox(self.widget.get_controls().show_controls_help)
                         .label("Show controls help")
                         .on_toggle(Message::ToggleShowControlsHelp),
                 ]

--- a/examples/interactive_spline.rs
+++ b/examples/interactive_spline.rs
@@ -2,12 +2,12 @@
 //!
 //! Demonstrates selectively disabling plot controls and handling drag events for custom interactivity.
 use iced::{
-    Element,
+    Element, mouse,
     widget::{column, text},
 };
 use iced_plot::{
-    Color, DragEvent, LineStyle, MarkerStyle, PanControls, PlotControls, PlotUiMessage, PlotWidget,
-    PlotWidgetBuilder, Series, ShapeId,
+    Color, DragEvent, LineStyle, MarkerStyle, PlotControls, PlotUiMessage, PlotWidget,
+    PlotWidgetBuilder, ScrollAction, Series, ShapeId,
 };
 
 fn main() -> iced::Result {
@@ -54,13 +54,11 @@ impl App {
             .with_label("catmull-rom spline")
             .with_color(Color::from_rgb(0.2, 0.8, 1.0));
 
-        let controls_cfg = PlotControls {
-            pan: PanControls {
-                scroll_to_pan: true,
-                drag_to_pan: false,
-            },
-            ..Default::default()
-        };
+        let mut controls_cfg = PlotControls::default();
+        controls_cfg.interaction.unbind_drag(mouse::Button::Left);
+        controls_cfg
+            .interaction
+            .bind_scroll(iced::keyboard::Modifiers::NONE, ScrollAction::Pan);
 
         let control_series_id = control_series.id;
         let control_poly_id = control_poly.id;

--- a/examples/interactive_spline.rs
+++ b/examples/interactive_spline.rs
@@ -98,7 +98,7 @@ impl App {
 
                 if let Some(drag_event) = drag_event {
                     match drag_event {
-                        DragEvent::Start { world } => {
+                        DragEvent::Start { world, .. } => {
                             self.active_control_point = nearest_control_point_index(
                                 &self.control_points,
                                 world,
@@ -106,7 +106,7 @@ impl App {
                             );
                             self.move_control_point(world);
                         }
-                        DragEvent::Update { world } => {
+                        DragEvent::Update { world, .. } => {
                             self.move_control_point(world);
                         }
                         DragEvent::End { .. } => {

--- a/examples/interactive_spline.rs
+++ b/examples/interactive_spline.rs
@@ -55,10 +55,8 @@ impl App {
             .with_color(Color::from_rgb(0.2, 0.8, 1.0));
 
         let mut controls_cfg = PlotControls::default();
-        controls_cfg.interaction.unbind_drag(mouse::Button::Left);
-        controls_cfg
-            .interaction
-            .bind_scroll(iced::keyboard::Modifiers::NONE, ScrollAction::Pan);
+        controls_cfg.unbind_drag(mouse::Button::Left);
+        controls_cfg.bind_scroll(iced::keyboard::Modifiers::NONE, ScrollAction::Pan);
 
         let control_series_id = control_series.id;
         let control_poly_id = control_poly.id;

--- a/examples/three_plots.rs
+++ b/examples/three_plots.rs
@@ -3,6 +3,7 @@
 //! on one plot will synchronize the others.
 use iced_plot::HighlightPoint;
 use iced_plot::HoverPickEvent;
+use iced_plot::PlotControls;
 use iced_plot::PlotUiMessage;
 use iced_plot::PlotWidget;
 use iced_plot::PlotWidgetBuilder;
@@ -12,6 +13,7 @@ use iced_plot::{AxisLink, LineStyle, MarkerStyle, Series, ShapeId};
 use iced::Color;
 use iced::Element;
 use iced::Length;
+use iced::keyboard;
 use iced::widget::{column, scrollable};
 
 fn main() -> iced::Result {
@@ -148,6 +150,11 @@ impl App {
     fn new() -> Self {
         // Create a shared x-axis link so all three plots pan/zoom together on the x-axis
         let x_link = AxisLink::new();
+        let no_scroll_pan_controls = || {
+            let mut controls = PlotControls::default();
+            controls.unbind_scroll(keyboard::Modifiers::NONE);
+            controls
+        };
 
         let positions = (0..100)
             .map(|i| {
@@ -159,7 +166,7 @@ impl App {
         let s1 = Series::line_only(positions, LineStyle::solid()).with_label("sine_line_only");
         let s1_id = s1.id;
         let w1 = PlotWidgetBuilder::new()
-            .disable_scroll_to_pan()
+            .with_controls(no_scroll_pan_controls())
             .with_hover_highlight_provider(Self::hover_highlight_provider)
             .with_pick_highlight_provider(Self::pick_highlight_provider)
             .with_x_lim(-1.0, 10.0) // Set x-axis limits
@@ -182,7 +189,7 @@ impl App {
             .with_color([0.9, 0.3, 0.3]);
         let s2_id = s2.id;
         let w2 = PlotWidgetBuilder::new()
-            .disable_scroll_to_pan()
+            .with_controls(no_scroll_pan_controls())
             .with_hover_highlight_provider(Self::hover_highlight_provider)
             .with_pick_highlight_provider(Self::pick_highlight_provider)
             .with_x_axis_link(x_link.clone()) // Link the x-axis
@@ -205,7 +212,7 @@ impl App {
             .with_color([0.3, 0.9, 0.3]);
         let s3_id = s3.id;
         let w3 = PlotWidgetBuilder::new()
-            .disable_scroll_to_pan()
+            .with_controls(no_scroll_pan_controls())
             .with_hover_highlight_provider(Self::hover_highlight_provider)
             .with_pick_highlight_provider(Self::pick_highlight_provider)
             .with_x_axis_link(x_link.clone()) // Link the x-axis

--- a/src/controls.rs
+++ b/src/controls.rs
@@ -1,16 +1,14 @@
 //! Controls for user interaction with the plot.
 
+use crate::message::PlotUiMessage;
+use iced::{Element, keyboard, mouse, widget};
+use std::collections::HashMap;
+
 /// Configures user interaction behavior for [`crate::PlotWidget`].
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct PlotControls {
-    /// Controls how panning is performed.
-    pub pan: PanControls,
-
-    /// Controls how zooming is performed.
-    pub zoom: ZoomControls,
-
-    /// Controls how points are picked and cleared.
-    pub pick: PickControls,
+    /// Controls how input triggers map to plot actions.
+    pub interaction: InteractionControls,
 
     /// Enables point highlighting while hovering.
     pub highlight_on_hover: bool,
@@ -19,37 +17,98 @@ pub struct PlotControls {
     pub show_controls_help: bool,
 }
 
-/// Configures panning interactions.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct PanControls {
-    /// Enables panning using the mouse wheel or trackpad scroll gesture.
-    pub scroll_to_pan: bool,
+/// Trigger-to-action configuration grouped by input family.
+#[derive(Debug, Clone, PartialEq)]
+pub struct InteractionControls {
+    /// Mouse button drag bindings.
+    pub drag: HashMap<mouse::Button, DragAction>,
 
-    /// Enables panning by dragging with the left mouse button.
-    pub drag_to_pan: bool,
+    /// Scroll bindings keyed by active keyboard modifiers.
+    pub scroll: HashMap<keyboard::Modifiers, ScrollAction>,
+
+    /// Mouse click bindings.
+    pub click: HashMap<mouse::Button, ClickAction>,
+
+    /// Mouse double-click bindings.
+    pub double_click: HashMap<mouse::Button, ClickAction>,
+
+    /// Keyboard key bindings.
+    pub key: HashMap<keyboard::Key, KeyAction>,
+
+    /// Minimum drag distance, in screen pixels, before a drag gesture is treated
+    /// as intentional instead of a click.
+    pub drag_delta_threshold: f32,
+
+    /// Fractional padding added around a completed box-zoom selection.
+    ///
+    /// For example, the default `0.02` expands the selected world-space bounds
+    /// by 2% before applying the new camera bounds.
+    pub selection_padding: f64,
 }
 
-/// Configures zoom interactions.
+/// Action that can be performed during a mouse drag.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct ZoomControls {
-    /// Enables box zoom via right-button drag.
-    pub box_zoom: bool,
+pub enum DragAction {
+    /// Pan the camera while dragging.
+    Pan,
 
-    /// Enables zooming at cursor while Ctrl is held during scroll.
-    pub scroll_with_ctrl: bool,
-
-    /// Enables double-click reset/autoscale behavior.
-    pub double_click_autoscale: bool,
+    /// Draw a selection rectangle and zoom to it on release.
+    BoxZoom,
 }
 
-/// Configures pick interactions.
+/// Action that can be performed by scrolling.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct PickControls {
-    /// Enables picking by left-clicking a highlighted point.
-    pub click_to_pick: bool,
+pub enum ScrollAction {
+    /// Pan the camera by the scroll delta.
+    Pan,
 
-    /// Enables clearing picked points with the Escape key.
-    pub clear_on_escape: bool,
+    /// Zoom at the cursor by the scroll delta.
+    Zoom,
+}
+
+/// Action that can be performed by a mouse click or double-click.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ClickAction {
+    /// Pick the currently highlighted point.
+    Pick,
+
+    /// Reset/autoscale the plot.
+    Autoscale,
+
+    /// Clear picked points.
+    ClearPick,
+}
+
+/// Action that can be performed by a key press.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum KeyAction {
+    /// Reset/autoscale the plot.
+    Autoscale,
+
+    /// Clear picked points.
+    ClearPick,
+
+    /// Pan by a fraction of the current visible camera span.
+    PanBy {
+        /// Direction to pan.
+        direction: PanDirection,
+
+        /// Fraction of the visible camera span to pan.
+        fraction: f64,
+    },
+}
+
+/// Direction for keyboard-style panning.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PanDirection {
+    /// Pan toward smaller x values.
+    Left,
+    /// Pan toward larger x values.
+    Right,
+    /// Pan toward larger y values.
+    Up,
+    /// Pan toward smaller y values.
+    Down,
 }
 
 // In keeping with our batteries-included philosophy, most everything is enabled by default.
@@ -57,39 +116,408 @@ pub struct PickControls {
 impl Default for PlotControls {
     fn default() -> Self {
         Self {
-            pan: PanControls::default(),
-            zoom: ZoomControls::default(),
-            pick: PickControls::default(),
+            interaction: InteractionControls::default(),
             highlight_on_hover: true,
             show_controls_help: true,
         }
     }
 }
 
-impl Default for ZoomControls {
+impl Default for InteractionControls {
     fn default() -> Self {
-        Self {
-            box_zoom: true,
-            scroll_with_ctrl: true,
-            double_click_autoscale: true,
-        }
+        let mut controls = Self {
+            drag: HashMap::new(),
+            scroll: HashMap::new(),
+            click: HashMap::new(),
+            double_click: HashMap::new(),
+            key: HashMap::new(),
+            drag_delta_threshold: 4.0,
+            selection_padding: 0.02,
+        };
+
+        controls
+            .bind_drag(mouse::Button::Left, DragAction::Pan)
+            .bind_drag(mouse::Button::Right, DragAction::BoxZoom)
+            .bind_scroll(keyboard::Modifiers::NONE, ScrollAction::Pan)
+            .bind_scroll(keyboard::Modifiers::CTRL, ScrollAction::Zoom)
+            .bind_click(mouse::Button::Left, ClickAction::Pick)
+            .bind_double_click(mouse::Button::Left, ClickAction::Autoscale)
+            .bind_key(
+                keyboard::Key::Named(keyboard::key::Named::Escape),
+                KeyAction::ClearPick,
+            );
+
+        controls.bind_arrow_pan(0.1);
+        controls
     }
 }
 
-impl Default for PanControls {
-    fn default() -> Self {
-        Self {
-            scroll_to_pan: true,
-            drag_to_pan: true,
+impl InteractionControls {
+    /// Bind a mouse drag trigger to an action.
+    pub fn bind_drag(&mut self, button: mouse::Button, action: DragAction) -> &mut Self {
+        self.drag.insert(button, action);
+        self
+    }
+
+    /// Remove a mouse drag binding.
+    pub fn unbind_drag(&mut self, button: mouse::Button) -> Option<DragAction> {
+        self.drag.remove(&button)
+    }
+
+    /// Return the action bound to a mouse drag trigger.
+    pub fn drag_action(&self, button: mouse::Button) -> Option<DragAction> {
+        self.drag.get(&button).copied()
+    }
+
+    /// Return whether a mouse drag trigger is bound to an action.
+    pub fn drag_is_bound(&self, button: mouse::Button, action: DragAction) -> bool {
+        self.drag_action(button) == Some(action)
+    }
+
+    /// Bind a scroll trigger to an action.
+    pub fn bind_scroll(
+        &mut self,
+        modifiers: keyboard::Modifiers,
+        action: ScrollAction,
+    ) -> &mut Self {
+        self.scroll.insert(modifiers, action);
+        self
+    }
+
+    /// Remove a scroll binding.
+    pub fn unbind_scroll(&mut self, modifiers: keyboard::Modifiers) -> Option<ScrollAction> {
+        self.scroll.remove(&modifiers)
+    }
+
+    /// Return the scroll action for active modifiers.
+    ///
+    /// Exact modifier bindings win. If no exact binding exists, a Ctrl binding
+    /// still matches when additional modifiers are held.
+    pub fn scroll_action(&self, modifiers: keyboard::Modifiers) -> Option<ScrollAction> {
+        self.scroll.get(&modifiers).copied().or_else(|| {
+            modifiers
+                .contains(keyboard::Modifiers::CTRL)
+                .then(|| self.scroll.get(&keyboard::Modifiers::CTRL).copied())
+                .flatten()
+        })
+    }
+
+    /// Return whether a scroll trigger is bound to an action.
+    pub fn scroll_is_bound(&self, modifiers: keyboard::Modifiers, action: ScrollAction) -> bool {
+        self.scroll.get(&modifiers).copied() == Some(action)
+    }
+
+    /// Bind a mouse click trigger to an action.
+    pub fn bind_click(&mut self, button: mouse::Button, action: ClickAction) -> &mut Self {
+        self.click.insert(button, action);
+        self
+    }
+
+    /// Remove a mouse click binding.
+    pub fn unbind_click(&mut self, button: mouse::Button) -> Option<ClickAction> {
+        self.click.remove(&button)
+    }
+
+    /// Return the action bound to a mouse click trigger.
+    pub fn click_action(&self, button: mouse::Button) -> Option<ClickAction> {
+        self.click.get(&button).copied()
+    }
+
+    /// Return whether a mouse click trigger is bound to an action.
+    pub fn click_is_bound(&self, button: mouse::Button, action: ClickAction) -> bool {
+        self.click_action(button) == Some(action)
+    }
+
+    /// Bind a mouse double-click trigger to an action.
+    pub fn bind_double_click(&mut self, button: mouse::Button, action: ClickAction) -> &mut Self {
+        self.double_click.insert(button, action);
+        self
+    }
+
+    /// Remove a mouse double-click binding.
+    pub fn unbind_double_click(&mut self, button: mouse::Button) -> Option<ClickAction> {
+        self.double_click.remove(&button)
+    }
+
+    /// Return the action bound to a mouse double-click trigger.
+    pub fn double_click_action(&self, button: mouse::Button) -> Option<ClickAction> {
+        self.double_click.get(&button).copied()
+    }
+
+    /// Return whether a mouse double-click trigger is bound to an action.
+    pub fn double_click_is_bound(&self, button: mouse::Button, action: ClickAction) -> bool {
+        self.double_click_action(button) == Some(action)
+    }
+
+    /// Bind a key trigger to an action.
+    pub fn bind_key(&mut self, key: keyboard::Key, action: KeyAction) -> &mut Self {
+        self.key.insert(key, action);
+        self
+    }
+
+    /// Remove a key binding.
+    pub fn unbind_key(&mut self, key: &keyboard::Key) -> Option<KeyAction> {
+        self.key.remove(key)
+    }
+
+    /// Return the key-press action for a key.
+    pub fn key_action(&self, key: &keyboard::Key) -> Option<KeyAction> {
+        self.key.get(key).copied()
+    }
+
+    /// Return whether a key trigger is bound to an action.
+    pub fn key_is_bound(&self, key: &keyboard::Key, action: KeyAction) -> bool {
+        self.key_action(key) == Some(action)
+    }
+
+    /// Remove all drag bindings for a given action.
+    pub fn remove_drag_action(&mut self, action: DragAction) -> &mut Self {
+        self.drag.retain(|_, bound| *bound != action);
+        self
+    }
+
+    /// Set the mouse button used for a drag action.
+    ///
+    /// Passing `None` disables the drag action.
+    pub fn set_drag_action(
+        &mut self,
+        action: DragAction,
+        button: Option<mouse::Button>,
+    ) -> &mut Self {
+        self.remove_drag_action(action);
+        if let Some(button) = button {
+            self.bind_drag(button, action);
         }
+        self
+    }
+
+    /// Remove all key bindings for a given action.
+    pub fn remove_key_action(&mut self, action: KeyAction) -> &mut Self {
+        self.key.retain(|_, bound| *bound != action);
+        self
+    }
+
+    /// Set the key used for a key action.
+    ///
+    /// Passing `None` disables the key action.
+    pub fn set_key_action(&mut self, action: KeyAction, key: Option<keyboard::Key>) -> &mut Self {
+        self.remove_key_action(action);
+        if let Some(key) = key {
+            self.bind_key(key, action);
+        }
+        self
+    }
+
+    /// Bind the four arrow keys to pan by the given fraction of the visible span.
+    pub fn bind_arrow_pan(&mut self, fraction: f64) -> &mut Self {
+        self.bind_key(
+            keyboard::Key::Named(keyboard::key::Named::ArrowLeft),
+            KeyAction::PanBy {
+                direction: PanDirection::Left,
+                fraction,
+            },
+        )
+        .bind_key(
+            keyboard::Key::Named(keyboard::key::Named::ArrowRight),
+            KeyAction::PanBy {
+                direction: PanDirection::Right,
+                fraction,
+            },
+        )
+        .bind_key(
+            keyboard::Key::Named(keyboard::key::Named::ArrowUp),
+            KeyAction::PanBy {
+                direction: PanDirection::Up,
+                fraction,
+            },
+        )
+        .bind_key(
+            keyboard::Key::Named(keyboard::key::Named::ArrowDown),
+            KeyAction::PanBy {
+                direction: PanDirection::Down,
+                fraction,
+            },
+        )
+    }
+
+    /// Remove all arrow-key pan bindings.
+    pub fn unbind_arrow_pan(&mut self) -> &mut Self {
+        for key in [
+            keyboard::key::Named::ArrowLeft,
+            keyboard::key::Named::ArrowRight,
+            keyboard::key::Named::ArrowUp,
+            keyboard::key::Named::ArrowDown,
+        ] {
+            let key = keyboard::Key::Named(key);
+            if matches!(self.key_action(&key), Some(KeyAction::PanBy { .. })) {
+                self.unbind_key(&key);
+            }
+        }
+        self
+    }
+
+    /// Return whether any trigger is bound to point picking.
+    pub fn has_pick_action(&self) -> bool {
+        self.click
+            .values()
+            .any(|action| *action == ClickAction::Pick)
+            || self
+                .double_click
+                .values()
+                .any(|action| *action == ClickAction::Pick)
+    }
+
+    /// Return whether all arrow keys are currently bound to pan actions.
+    pub fn arrows_to_pan_enabled(&self) -> bool {
+        [
+            keyboard::key::Named::ArrowLeft,
+            keyboard::key::Named::ArrowRight,
+            keyboard::key::Named::ArrowUp,
+            keyboard::key::Named::ArrowDown,
+        ]
+        .into_iter()
+        .all(|key| {
+            matches!(
+                self.key_action(&keyboard::Key::Named(key)),
+                Some(KeyAction::PanBy { .. })
+            )
+        })
     }
 }
 
-impl Default for PickControls {
-    fn default() -> Self {
-        Self {
-            click_to_pick: true,
-            clear_on_escape: true,
+impl PlotControls {
+    pub(crate) fn view_controls_overlay_panel(
+        &self,
+        has_legend: bool,
+    ) -> Element<'_, PlotUiMessage> {
+        let txt = |t| widget::text(t).size(12.0).style(widget::text::base);
+        let mut content =
+            widget::column![txt("Controls").style(widget::text::primary)].spacing(2.0);
+
+        let mut bindings = self.interaction.binding_descriptions();
+        bindings.sort();
+
+        for binding in bindings {
+            content = content.push(widget::text(binding).size(12.0).style(widget::text::base));
         }
+        if has_legend {
+            content = content.push(txt("Click icon in legend to toggle visibility."));
+        }
+
+        content.into()
+    }
+}
+
+impl InteractionControls {
+    fn binding_descriptions(&self) -> Vec<String> {
+        let mut bindings = Vec::new();
+
+        bindings.extend(self.drag.iter().map(|(button, action)| {
+            format!(
+                "{}-drag: {}",
+                mouse_button_label(*button),
+                drag_action_label(*action)
+            )
+        }));
+        bindings.extend(self.scroll.iter().map(|(modifiers, action)| {
+            let trigger = if modifiers.is_empty() {
+                "Scroll".to_owned()
+            } else {
+                format!("{} + scroll", keyboard_modifiers_label(*modifiers))
+            };
+            format!("{trigger}: {}", scroll_action_label(*action))
+        }));
+        bindings.extend(self.click.iter().map(|(button, action)| {
+            format!(
+                "{}-click: {}",
+                mouse_button_label(*button),
+                click_action_label(*action)
+            )
+        }));
+        bindings.extend(self.double_click.iter().map(|(button, action)| {
+            format!(
+                "{} double-click: {}",
+                mouse_button_label(*button),
+                click_action_label(*action)
+            )
+        }));
+        bindings.extend(self.key.iter().map(|(key, action)| {
+            format!("{}: {}", keyboard_key_label(key), key_action_label(*action))
+        }));
+
+        bindings
+    }
+}
+
+fn mouse_button_label(button: mouse::Button) -> String {
+    match button {
+        mouse::Button::Left => "Left".to_owned(),
+        mouse::Button::Right => "Right".to_owned(),
+        mouse::Button::Middle => "Middle".to_owned(),
+        mouse::Button::Back => "Back".to_owned(),
+        mouse::Button::Forward => "Forward".to_owned(),
+        mouse::Button::Other(number) => format!("Mouse {number}"),
+    }
+}
+
+fn keyboard_key_label(key: &keyboard::Key) -> String {
+    match key {
+        keyboard::Key::Named(named) => format!("{named:?}"),
+        keyboard::Key::Character(character) => character.to_string(),
+        keyboard::Key::Unidentified => "Unidentified".to_owned(),
+    }
+}
+
+fn drag_action_label(action: DragAction) -> &'static str {
+    match action {
+        DragAction::Pan => "pan",
+        DragAction::BoxZoom => "box zoom",
+    }
+}
+
+fn scroll_action_label(action: ScrollAction) -> &'static str {
+    match action {
+        ScrollAction::Pan => "pan",
+        ScrollAction::Zoom => "zoom at cursor",
+    }
+}
+
+fn click_action_label(action: ClickAction) -> &'static str {
+    match action {
+        ClickAction::Pick => "pick point",
+        ClickAction::Autoscale => "reset / autoscale",
+        ClickAction::ClearPick => "clear picked points",
+    }
+}
+
+fn key_action_label(action: KeyAction) -> String {
+    match action {
+        KeyAction::Autoscale => "reset / autoscale".to_owned(),
+        KeyAction::ClearPick => "clear picked points".to_owned(),
+        KeyAction::PanBy {
+            direction,
+            fraction,
+        } => format!("pan {direction:?} by {:.0}%", fraction * 100.0),
+    }
+}
+
+fn keyboard_modifiers_label(modifiers: keyboard::Modifiers) -> String {
+    let mut labels = Vec::new();
+    if modifiers.contains(keyboard::Modifiers::CTRL) {
+        labels.push("Ctrl");
+    }
+    if modifiers.contains(keyboard::Modifiers::SHIFT) {
+        labels.push("Shift");
+    }
+    if modifiers.contains(keyboard::Modifiers::ALT) {
+        labels.push("Alt");
+    }
+    if modifiers.contains(keyboard::Modifiers::LOGO) {
+        labels.push("Logo");
+    }
+    if labels.is_empty() {
+        "No modifier".to_owned()
+    } else {
+        labels.join(" + ")
     }
 }

--- a/src/controls.rs
+++ b/src/controls.rs
@@ -7,43 +7,30 @@ use std::collections::HashMap;
 /// Configures user interaction behavior for [`crate::PlotWidget`].
 #[derive(Debug, Clone, PartialEq)]
 pub struct PlotControls {
-    /// Controls how input triggers map to plot actions.
-    pub interaction: InteractionControls,
-
-    /// Enables point highlighting while hovering.
-    pub highlight_on_hover: bool,
-
-    /// Shows the in-canvas controls/help UI (`?` button).
-    pub show_controls_help: bool,
-}
-
-/// Trigger-to-action configuration grouped by input family.
-#[derive(Debug, Clone, PartialEq)]
-pub struct InteractionControls {
     /// Mouse button drag bindings.
-    pub drag: HashMap<mouse::Button, DragAction>,
+    drag: HashMap<mouse::Button, DragAction>,
 
     /// Scroll bindings keyed by active keyboard modifiers.
-    pub scroll: HashMap<keyboard::Modifiers, ScrollAction>,
+    scroll: HashMap<keyboard::Modifiers, ScrollAction>,
 
     /// Mouse click bindings.
-    pub click: HashMap<mouse::Button, ClickAction>,
+    click: HashMap<mouse::Button, ClickAction>,
 
     /// Mouse double-click bindings.
-    pub double_click: HashMap<mouse::Button, ClickAction>,
+    double_click: HashMap<mouse::Button, ClickAction>,
 
     /// Keyboard key bindings.
-    pub key: HashMap<keyboard::Key, KeyAction>,
+    key: HashMap<keyboard::Key, KeyAction>,
 
     /// Minimum drag distance, in screen pixels, before a drag gesture is treated
     /// as intentional instead of a click.
-    pub drag_delta_threshold: f32,
+    drag_delta_threshold: f32,
 
     /// Fractional padding added around a completed box-zoom selection.
     ///
     /// For example, the default `0.02` expands the selected world-space bounds
     /// by 2% before applying the new camera bounds.
-    pub selection_padding: f64,
+    selection_padding: f64,
 }
 
 /// Action that can be performed during a mouse drag.
@@ -115,16 +102,6 @@ pub enum PanDirection {
 
 impl Default for PlotControls {
     fn default() -> Self {
-        Self {
-            interaction: InteractionControls::default(),
-            highlight_on_hover: true,
-            show_controls_help: true,
-        }
-    }
-}
-
-impl Default for InteractionControls {
-    fn default() -> Self {
         let mut controls = Self {
             drag: HashMap::new(),
             scroll: HashMap::new(),
@@ -152,7 +129,7 @@ impl Default for InteractionControls {
     }
 }
 
-impl InteractionControls {
+impl PlotControls {
     /// Bind a mouse drag trigger to an action.
     pub fn bind_drag(&mut self, button: mouse::Button, action: DragAction) -> &mut Self {
         self.drag.insert(button, action);
@@ -268,6 +245,30 @@ impl InteractionControls {
     /// Return whether a key trigger is bound to an action.
     pub fn key_is_bound(&self, key: &keyboard::Key, action: KeyAction) -> bool {
         self.key_action(key) == Some(action)
+    }
+
+    /// Return the minimum drag distance, in screen pixels, required before a
+    /// press is treated as a drag instead of a click.
+    pub fn drag_delta_threshold(&self) -> f32 {
+        self.drag_delta_threshold
+    }
+
+    /// Set the minimum drag distance, in screen pixels, required before a press
+    /// is treated as a drag instead of a click.
+    pub fn set_drag_delta_threshold(&mut self, threshold: f32) -> &mut Self {
+        self.drag_delta_threshold = threshold.max(0.0);
+        self
+    }
+
+    /// Return the fractional padding added around box-zoom selections.
+    pub fn selection_padding(&self) -> f64 {
+        self.selection_padding
+    }
+
+    /// Set the fractional padding added around box-zoom selections.
+    pub fn set_selection_padding(&mut self, padding: f64) -> &mut Self {
+        self.selection_padding = padding.max(0.0);
+        self
     }
 
     /// Remove all drag bindings for a given action.
@@ -394,7 +395,7 @@ impl PlotControls {
         let mut content =
             widget::column![txt("Controls").style(widget::text::primary)].spacing(2.0);
 
-        let mut bindings = self.interaction.binding_descriptions();
+        let mut bindings = self.binding_descriptions();
         bindings.sort();
 
         for binding in bindings {
@@ -408,7 +409,7 @@ impl PlotControls {
     }
 }
 
-impl InteractionControls {
+impl PlotControls {
     fn binding_descriptions(&self) -> Vec<String> {
         let mut bindings = Vec::new();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,10 +50,7 @@ pub use iced::Color;
 // Re-exports of public types.
 pub use axis_link::AxisLink;
 pub use axis_scale::AxisScale;
-pub use controls::{
-    ClickAction, DragAction, InteractionControls, KeyAction, PanDirection, PlotControls,
-    ScrollAction,
-};
+pub use controls::{ClickAction, DragAction, KeyAction, PanDirection, PlotControls, ScrollAction};
 pub use fill::Fill;
 pub use grid::TickWeight;
 pub use message::{DragEvent, HoverPickEvent, PlotUiMessage, PointId, TooltipContext};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,10 @@ pub use iced::Color;
 // Re-exports of public types.
 pub use axis_link::AxisLink;
 pub use axis_scale::AxisScale;
-pub use controls::{PanControls, PickControls, PlotControls, ZoomControls};
+pub use controls::{
+    ClickAction, DragAction, InteractionControls, KeyAction, PanDirection, PlotControls,
+    ScrollAction,
+};
 pub use fill::Fill;
 pub use grid::TickWeight;
 pub use message::{DragEvent, HoverPickEvent, PlotUiMessage, PointId, TooltipContext};

--- a/src/message.rs
+++ b/src/message.rs
@@ -88,16 +88,22 @@ pub struct PlotRenderUpdate {
 pub enum DragEvent {
     /// A drag gesture started inside the plot.
     Start {
+        /// Mouse button that initiated the drag stream.
+        button: iced::mouse::Button,
         /// Current cursor world/data coordinate.
         world: [f64; 2],
     },
     /// Cursor moved while drag is active.
     Update {
+        /// Mouse button that initiated the drag stream.
+        button: iced::mouse::Button,
         /// Current cursor world/data coordinate.
         world: [f64; 2],
     },
     /// Active drag gesture ended.
     End {
+        /// Mouse button that initiated the drag stream.
+        button: iced::mouse::Button,
         /// Current cursor world/data coordinate.
         world: [f64; 2],
     },

--- a/src/plot_state.rs
+++ b/src/plot_state.rs
@@ -557,14 +557,10 @@ impl PlotState {
                 self.press.start = self.cursor_position;
 
                 let double_click_pending = self.is_double_click(button)
-                    && widget
-                        .controls
-                        .interaction
-                        .double_click_action(button)
-                        .is_some();
+                    && widget.controls.double_click_action(button).is_some();
 
                 if !double_click_pending {
-                    match widget.controls.interaction.drag_action(button) {
+                    match widget.controls.drag_action(button) {
                         Some(DragAction::BoxZoom) => {
                             self.selection.active = true;
                             self.selection.button = Some(button);
@@ -582,13 +578,9 @@ impl PlotState {
                         _ => {}
                     }
 
-                    if button == mouse::Button::Left
-                        && !matches!(
-                            widget.controls.interaction.drag_action(button),
-                            Some(DragAction::BoxZoom)
-                        )
-                    {
+                    if widget.controls.drag_action(button).is_none() {
                         self.drag.active = true;
+                        self.drag.button = Some(button);
                         if let Some(world) = self.cursor_world_data(viewport) {
                             *publish_drag_event = Some(DragEvent::Start { world });
                         }
@@ -598,17 +590,19 @@ impl PlotState {
             Event::ButtonReleased(button) => {
                 let click_candidate = self.press.button == Some(button)
                     && (self.cursor_position - self.press.start).length()
-                        <= widget.controls.interaction.drag_delta_threshold;
+                        <= widget.controls.drag_delta_threshold();
 
-                if button == mouse::Button::Left
-                    && self.drag.active
+                if self.drag.active
+                    && self.drag.button == Some(button)
                     && let Some(world) = self.cursor_world_data(viewport)
                 {
                     *publish_drag_event = Some(DragEvent::End { world });
                     self.drag.active = false;
+                    self.drag.button = None;
                 }
-                if button == mouse::Button::Left {
+                if self.drag.button == Some(button) {
                     self.drag.active = false;
+                    self.drag.button = None;
                 }
                 if self.pan.active && self.pan.button == Some(button) {
                     self.pan.active = false;
@@ -617,7 +611,7 @@ impl PlotState {
                 if self.selection.active && self.selection.button == Some(button) {
                     self.selection.end = self.cursor_position;
                     let delta = self.selection.end - self.selection.start;
-                    let dragged = delta.length() > widget.controls.interaction.drag_delta_threshold;
+                    let dragged = delta.length() > widget.controls.drag_delta_threshold();
                     // Perform zoom if user actually dragged a region of non-trivial size
                     if dragged {
                         // Convert screen (pixels) to world coords using camera helper
@@ -638,7 +632,7 @@ impl PlotState {
                         self.camera.set_bounds_preserve_offset(
                             min_v,
                             max_v,
-                            widget.controls.interaction.selection_padding,
+                            widget.controls.selection_padding(),
                         );
                         self.update_axis_links();
                     }
@@ -670,7 +664,7 @@ impl PlotState {
                     iced::mouse::ScrollDelta::Pixels { x, y } => (x, y),
                 };
 
-                match widget.controls.interaction.scroll_action(self.modifiers) {
+                match widget.controls.scroll_action(self.modifiers) {
                     Some(ScrollAction::Zoom) => {
                         self.zoom_at_cursor(y, viewport);
                         needs_redraw = true;
@@ -715,7 +709,7 @@ impl PlotState {
             return false;
         }
 
-        match widget.controls.interaction.key_action(key) {
+        match widget.controls.key_action(key) {
             Some(KeyAction::Autoscale) => {
                 self.autoscale(true);
                 true
@@ -757,8 +751,8 @@ impl PlotState {
     ) -> bool {
         let now = Instant::now();
         let double = self.is_double_click(button);
-        let double_action = widget.controls.interaction.double_click_action(button);
-        let click_action = widget.controls.interaction.click_action(button);
+        let double_action = widget.controls.double_click_action(button);
+        let click_action = widget.controls.click_action(button);
 
         let handled = if double {
             double_action
@@ -1220,6 +1214,7 @@ pub(crate) struct PanState {
 #[derive(Default, Debug, Clone)]
 pub(crate) struct DragState {
     pub(crate) active: bool,
+    pub(crate) button: Option<mouse::Button>,
 }
 
 #[cfg(test)]
@@ -1251,7 +1246,7 @@ mod tests {
     #[test]
     fn arrow_keys_use_configured_pan_fraction_when_enabled_and_hovered() {
         let mut widget = PlotWidget::new();
-        widget.controls.interaction.bind_key(
+        widget.controls.bind_key(
             keyboard::Key::Named(keyboard::key::Named::ArrowRight),
             KeyAction::PanBy {
                 direction: PanDirection::Right,
@@ -1285,7 +1280,7 @@ mod tests {
     #[test]
     fn arrow_keys_do_not_pan_when_disabled() {
         let mut widget = PlotWidget::new();
-        widget.controls.interaction.unbind_arrow_pan();
+        widget.controls.unbind_arrow_pan();
 
         let mut state = PlotState::default();
         state.bounds = Rectangle {
@@ -1312,7 +1307,6 @@ mod tests {
         let mut widget = PlotWidget::new();
         widget
             .controls
-            .interaction
             .set_drag_action(DragAction::Pan, Some(mouse::Button::Middle));
 
         let mut state = PlotState::default();
@@ -1350,11 +1344,50 @@ mod tests {
     }
 
     #[test]
+    fn unbound_non_left_button_publishes_drag_events() {
+        let widget = PlotWidget::new();
+        let mut state = PlotState::default();
+        state.bounds = Rectangle {
+            x: 0.0,
+            y: 0.0,
+            width: 100.0,
+            height: 100.0,
+        };
+        state.cursor_position = Vec2::new(50.0, 50.0);
+
+        let mut hover_pick = None;
+        let mut drag_event = None;
+        state.handle_mouse_event(
+            Event::ButtonPressed(mouse::Button::Middle),
+            mouse::Cursor::Available(Point::new(50.0, 50.0)),
+            &widget,
+            &mut hover_pick,
+            &mut drag_event,
+        );
+
+        assert!(matches!(drag_event, Some(DragEvent::Start { .. })));
+        assert!(state.drag.active);
+        assert_eq!(state.drag.button, Some(mouse::Button::Middle));
+
+        drag_event = None;
+        state.handle_mouse_event(
+            Event::ButtonReleased(mouse::Button::Middle),
+            mouse::Cursor::Available(Point::new(50.0, 50.0)),
+            &widget,
+            &mut hover_pick,
+            &mut drag_event,
+        );
+
+        assert!(matches!(drag_event, Some(DragEvent::End { .. })));
+        assert!(!state.drag.active);
+        assert_eq!(state.drag.button, None);
+    }
+
+    #[test]
     fn left_click_picks_when_left_button_is_box_zoom() {
         let mut widget = PlotWidget::new();
         widget
             .controls
-            .interaction
             .set_drag_action(DragAction::Pan, Some(mouse::Button::Right))
             .set_drag_action(DragAction::BoxZoom, Some(mouse::Button::Left));
 
@@ -1399,7 +1432,6 @@ mod tests {
         let mut widget = PlotWidget::new();
         widget
             .controls
-            .interaction
             .set_drag_action(DragAction::Pan, Some(mouse::Button::Right))
             .set_drag_action(DragAction::BoxZoom, Some(mouse::Button::Left));
 
@@ -1441,7 +1473,7 @@ mod tests {
     #[test]
     fn configured_key_autoscales_when_hovered() {
         let mut widget = PlotWidget::new();
-        widget.controls.interaction.bind_key(
+        widget.controls.bind_key(
             keyboard::Key::Named(keyboard::key::Named::Home),
             KeyAction::Autoscale,
         );

--- a/src/plot_state.rs
+++ b/src/plot_state.rs
@@ -8,8 +8,8 @@ use iced::{
 };
 
 use crate::{
-    AxisLink, AxisScale, DragEvent, HLine, HoverPickEvent, LineStyle, PlotWidget, Point, ShapeId,
-    Size, VLine,
+    AxisLink, AxisScale, ClickAction, DragAction, DragEvent, HLine, HoverPickEvent, KeyAction,
+    LineStyle, PanDirection, PlotWidget, Point, ScrollAction, ShapeId, Size, VLine,
     axis_scale::plot_point_to_data,
     camera::Camera,
     picking::PickingState,
@@ -53,8 +53,10 @@ pub struct PlotState {
     // Interaction state
     pub(crate) cursor_position: Vec2,
     pub(crate) last_click_time: Option<Instant>,
+    pub(crate) last_click_button: Option<mouse::Button>,
     pub(crate) legend_collapsed: bool,
     pub(crate) modifiers: keyboard::Modifiers,
+    pub(crate) press: ButtonPressState,
     pub(crate) selection: SelectionState,
     pub(crate) pan: PanState,
     pub(crate) drag: DragState,
@@ -105,8 +107,10 @@ impl Default for PlotState {
             grid_style: GridStyle::default(),
             cursor_position: Vec2::ZERO,
             last_click_time: None,
+            last_click_button: None,
             legend_collapsed: false,
             modifiers: keyboard::Modifiers::default(),
+            press: ButtonPressState::default(),
             selection: SelectionState::default(),
             pan: PanState::default(),
             drag: DragState::default(),
@@ -461,9 +465,6 @@ impl PlotState {
         publish_hover_pick: &mut Option<HoverPickEvent>,
         publish_drag_event: &mut Option<DragEvent>,
     ) -> bool {
-        const SELECTION_DELTA_THRESHOLD: f32 = 4.0; // pixels
-        const SELECTION_PADDING: f32 = 0.02; // fractional padding in world units relative to selection size
-
         // Only request redraws when something actually changes or when we need
         // to service a picking request for a new cursor position.
         let mut needs_redraw = false;
@@ -543,88 +544,80 @@ impl PlotState {
                     needs_redraw = true;
                 }
             }
-            Event::ButtonPressed(mouse::Button::Left) => {
-                // Only start panning if the press started inside our bounds
-                // (Drags will continue even if the cursor leaves later)
+            Event::ButtonPressed(button) => {
+                // Only start button-driven interactions when the press starts
+                // inside our bounds. Drags continue even if the cursor leaves.
                 let inside = self.cursor_inside();
                 if !inside {
                     return needs_redraw;
                 }
-                let now = Instant::now();
-                let double = if let Some(prev) = self.last_click_time {
-                    now.duration_since(prev).as_millis() < 350
-                } else {
-                    false
-                };
-                self.last_click_time = Some(now);
-                if double && widget.controls.zoom.double_click_autoscale {
-                    self.autoscale(true);
-                    needs_redraw = true;
-                } else {
-                    if self.pick_enabled
-                        && widget.controls.pick.click_to_pick
-                        && !self.pan.active
-                        && !self.selection.active
-                    {
-                        // check if the cursor is hovering over a point
-                        let picked =
-                            if let Some(HoverPickEvent::Hover(point_id)) = *publish_hover_pick {
-                                Some(point_id)
-                            } else {
-                                widget.pick_hit(self)
-                            };
 
-                        if let Some(point_id) = picked {
-                            // Upgrade the "hover" to a "pick".
-                            *publish_hover_pick = Some(HoverPickEvent::Pick(point_id));
+                self.press.active = true;
+                self.press.button = Some(button);
+                self.press.start = self.cursor_position;
+
+                let double_click_pending = self.is_double_click(button)
+                    && widget
+                        .controls
+                        .interaction
+                        .double_click_action(button)
+                        .is_some();
+
+                if !double_click_pending {
+                    match widget.controls.interaction.drag_action(button) {
+                        Some(DragAction::BoxZoom) => {
+                            self.selection.active = true;
+                            self.selection.button = Some(button);
+                            self.selection.start = self.cursor_position;
+                            self.selection.end = self.cursor_position;
+                            self.selection.moved = false;
+                            needs_redraw = true;
                         }
+                        Some(DragAction::Pan) => {
+                            self.pan.active = true;
+                            self.pan.button = Some(button);
+                            self.pan.start_cursor = self.cursor_position.into();
+                            self.pan.start_camera_center = self.camera.position;
+                        }
+                        _ => {}
                     }
 
-                    self.drag.active = true;
-                    if let Some(world) = self.cursor_world_data(viewport) {
-                        *publish_drag_event = Some(DragEvent::Start { world });
-                    }
-
-                    if widget.controls.pan.drag_to_pan {
-                        // Start panning
-                        self.pan.active = true;
-                        self.pan.start_cursor = self.cursor_position.into();
-                        self.pan.start_camera_center = self.camera.position;
+                    if button == mouse::Button::Left
+                        && !matches!(
+                            widget.controls.interaction.drag_action(button),
+                            Some(DragAction::BoxZoom)
+                        )
+                    {
+                        self.drag.active = true;
+                        if let Some(world) = self.cursor_world_data(viewport) {
+                            *publish_drag_event = Some(DragEvent::Start { world });
+                        }
                     }
                 }
             }
-            Event::ButtonReleased(mouse::Button::Left) => {
-                if self.drag.active
+            Event::ButtonReleased(button) => {
+                let click_candidate = self.press.button == Some(button)
+                    && (self.cursor_position - self.press.start).length()
+                        <= widget.controls.interaction.drag_delta_threshold;
+
+                if button == mouse::Button::Left
+                    && self.drag.active
                     && let Some(world) = self.cursor_world_data(viewport)
                 {
                     *publish_drag_event = Some(DragEvent::End { world });
+                    self.drag.active = false;
                 }
-                self.drag.active = false;
-                if self.pan.active {
+                if button == mouse::Button::Left {
+                    self.drag.active = false;
+                }
+                if self.pan.active && self.pan.button == Some(button) {
                     self.pan.active = false;
+                    self.pan.button = None;
                 }
-            }
-            Event::ButtonPressed(mouse::Button::Right) => {
-                if !widget.controls.zoom.box_zoom {
-                    return needs_redraw;
-                }
-                // Only start selection if inside our bounds
-                let inside = self.cursor_inside();
-                if !inside {
-                    return needs_redraw;
-                }
-                // Start selection
-                self.selection.active = true;
-                self.selection.start = self.cursor_position;
-                self.selection.end = self.cursor_position;
-                self.selection.moved = false;
-                needs_redraw = true;
-            }
-            Event::ButtonReleased(mouse::Button::Right) => {
-                if self.selection.active {
+                if self.selection.active && self.selection.button == Some(button) {
                     self.selection.end = self.cursor_position;
                     let delta = self.selection.end - self.selection.start;
-                    let dragged = delta.length() > SELECTION_DELTA_THRESHOLD;
+                    let dragged = delta.length() > widget.controls.interaction.drag_delta_threshold;
                     // Perform zoom if user actually dragged a region of non-trivial size
                     if dragged {
                         // Convert screen (pixels) to world coords using camera helper
@@ -645,14 +638,24 @@ impl PlotState {
                         self.camera.set_bounds_preserve_offset(
                             min_v,
                             max_v,
-                            SELECTION_PADDING as f64,
+                            widget.controls.interaction.selection_padding,
                         );
                         self.update_axis_links();
                     }
                     // Clear selection overlay after release
                     self.selection.active = false;
+                    self.selection.button = None;
                     self.selection.moved = false;
                     needs_redraw = true;
+                }
+
+                if click_candidate && self.handle_mouse_click(button, widget, publish_hover_pick) {
+                    needs_redraw = true;
+                }
+
+                if self.press.button == Some(button) {
+                    self.press.active = false;
+                    self.press.button = None;
                 }
             }
             Event::WheelScrolled { delta } => {
@@ -667,42 +670,22 @@ impl PlotState {
                     iced::mouse::ScrollDelta::Pixels { x, y } => (x, y),
                 };
 
-                // Only zoom when Ctrl is held down
-                if widget.controls.zoom.scroll_with_ctrl
-                    && self.modifiers.contains(keyboard::Modifiers::CTRL)
-                {
-                    // Apply zoom factor based on scroll direction
-                    let zoom_factor = if y > 0.0 { 0.95 } else { 1.05 };
-
-                    // Convert cursor position to render coordinates before zoom (without offset)
-                    let cursor_render_before = self.camera.screen_to_render(
-                        DVec2::new(self.cursor_position.x as f64, self.cursor_position.y as f64),
-                        viewport,
-                    );
-
-                    // Apply zoom by scaling half_extents
-                    self.camera.half_extents *= zoom_factor;
-
-                    // Convert cursor position to render coordinates after zoom
-                    let cursor_render_after = self.camera.screen_to_render(
-                        DVec2::new(self.cursor_position.x as f64, self.cursor_position.y as f64),
-                        viewport,
-                    );
-
-                    // Adjust camera position (in render space) to keep cursor at same position
-                    let render_delta = cursor_render_before - cursor_render_after;
-                    // Convert render delta back to world space and adjust camera position
-                    self.camera.position += render_delta;
-
-                    self.update_axis_links();
-                    needs_redraw = true;
-                } else if widget.controls.pan.scroll_to_pan {
-                    let world_pan_x = -x as f64 * (self.camera.half_extents.x / (viewport.x / 2.0));
-                    let world_pan_y = y as f64 * (self.camera.half_extents.y / (viewport.y / 2.0));
-                    self.camera.position.x += world_pan_x;
-                    self.camera.position.y += world_pan_y;
-                    self.update_axis_links();
-                    needs_redraw = true;
+                match widget.controls.interaction.scroll_action(self.modifiers) {
+                    Some(ScrollAction::Zoom) => {
+                        self.zoom_at_cursor(y, viewport);
+                        needs_redraw = true;
+                    }
+                    Some(ScrollAction::Pan) => {
+                        let world_pan_x =
+                            -x as f64 * (self.camera.half_extents.x / (viewport.x / 2.0));
+                        let world_pan_y =
+                            y as f64 * (self.camera.half_extents.y / (viewport.y / 2.0));
+                        self.camera.position.x += world_pan_x;
+                        self.camera.position.y += world_pan_y;
+                        self.update_axis_links();
+                        needs_redraw = true;
+                    }
+                    _ => {}
                 }
             }
             _ => {}
@@ -712,11 +695,40 @@ impl PlotState {
         needs_redraw
     }
 
-    pub(crate) fn handle_keyboard_event(&mut self, event: &keyboard::Event) -> bool {
+    pub(crate) fn handle_keyboard_event(
+        &mut self,
+        event: &keyboard::Event,
+        widget: &PlotWidget,
+        cursor: mouse::Cursor,
+    ) -> bool {
         if let keyboard::Event::ModifiersChanged(modifiers) = event {
             self.modifiers = *modifiers;
         }
-        false // No need to redraw
+
+        let cursor_over = cursor.is_over(self.bounds);
+
+        let keyboard::Event::KeyPressed { key, .. } = event else {
+            return false;
+        };
+
+        if !cursor_over {
+            return false;
+        }
+
+        match widget.controls.interaction.key_action(key) {
+            Some(KeyAction::Autoscale) => {
+                self.autoscale(true);
+                true
+            }
+            Some(KeyAction::PanBy {
+                direction,
+                fraction,
+            }) => {
+                self.pan_by(direction, fraction);
+                true
+            }
+            _ => false,
+        }
     }
 
     fn update_axis_links(&mut self) {
@@ -728,6 +740,112 @@ impl PlotState {
             link.set(self.camera.position.y, self.camera.half_extents.y);
             self.y_link_version = link.version();
         }
+    }
+
+    fn is_double_click(&self, button: mouse::Button) -> bool {
+        self.last_click_button == Some(button)
+            && self
+                .last_click_time
+                .is_some_and(|prev| Instant::now().duration_since(prev).as_millis() < 350)
+    }
+
+    fn handle_mouse_click(
+        &mut self,
+        button: mouse::Button,
+        widget: &PlotWidget,
+        publish_hover_pick: &mut Option<HoverPickEvent>,
+    ) -> bool {
+        let now = Instant::now();
+        let double = self.is_double_click(button);
+        let double_action = widget.controls.interaction.double_click_action(button);
+        let click_action = widget.controls.interaction.click_action(button);
+
+        let handled = if double {
+            double_action
+                .or(click_action)
+                .is_some_and(|action| self.apply_click_action(action, widget, publish_hover_pick))
+        } else {
+            click_action
+                .is_some_and(|action| self.apply_click_action(action, widget, publish_hover_pick))
+        };
+
+        self.last_click_time = Some(now);
+        self.last_click_button = Some(button);
+        handled
+    }
+
+    fn apply_click_action(
+        &mut self,
+        action: ClickAction,
+        widget: &PlotWidget,
+        publish_hover_pick: &mut Option<HoverPickEvent>,
+    ) -> bool {
+        match action {
+            ClickAction::Autoscale => {
+                self.autoscale(true);
+                true
+            }
+            ClickAction::Pick => {
+                self.pick_highlighted_point(widget, publish_hover_pick);
+                false
+            }
+            ClickAction::ClearPick => {
+                *publish_hover_pick = Some(HoverPickEvent::ClearPick);
+                false
+            }
+        }
+    }
+
+    fn pick_highlighted_point(
+        &mut self,
+        widget: &PlotWidget,
+        publish_hover_pick: &mut Option<HoverPickEvent>,
+    ) {
+        if !self.pick_enabled || self.pan.active || self.selection.active {
+            return;
+        }
+
+        let picked = if let Some(HoverPickEvent::Hover(point_id)) = *publish_hover_pick {
+            Some(point_id)
+        } else {
+            widget.pick_hit(self)
+        };
+
+        if let Some(point_id) = picked {
+            *publish_hover_pick = Some(HoverPickEvent::Pick(point_id));
+        }
+    }
+
+    fn zoom_at_cursor(&mut self, scroll_y: f32, viewport: DVec2) {
+        let zoom_factor = if scroll_y > 0.0 { 0.95 } else { 1.05 };
+
+        let cursor_render_before = self.camera.screen_to_render(
+            DVec2::new(self.cursor_position.x as f64, self.cursor_position.y as f64),
+            viewport,
+        );
+
+        self.camera.half_extents *= zoom_factor;
+
+        let cursor_render_after = self.camera.screen_to_render(
+            DVec2::new(self.cursor_position.x as f64, self.cursor_position.y as f64),
+            viewport,
+        );
+
+        self.camera.position += cursor_render_before - cursor_render_after;
+        self.update_axis_links();
+    }
+
+    fn pan_by(&mut self, direction: PanDirection, fraction: f64) {
+        let delta = self.camera.half_extents * (2.0 * fraction);
+        let pan_delta = match direction {
+            PanDirection::Left => DVec2::new(-delta.x, 0.0),
+            PanDirection::Right => DVec2::new(delta.x, 0.0),
+            PanDirection::Up => DVec2::new(0.0, delta.y),
+            PanDirection::Down => DVec2::new(0.0, -delta.y),
+        };
+
+        self.camera.position += pan_delta;
+        self.update_axis_links();
     }
 
     fn cursor_world_data(&self, viewport: DVec2) -> Option<[f64; 2]> {
@@ -1076,8 +1194,16 @@ pub(crate) struct SeriesSpan {
 }
 
 #[derive(Default, Debug, Clone)]
+pub(crate) struct ButtonPressState {
+    pub(crate) active: bool,
+    pub(crate) button: Option<mouse::Button>,
+    pub(crate) start: Vec2,
+}
+
+#[derive(Default, Debug, Clone)]
 pub(crate) struct SelectionState {
     pub(crate) active: bool,
+    pub(crate) button: Option<mouse::Button>,
     pub(crate) start: Vec2,
     pub(crate) end: Vec2,
     pub(crate) moved: bool,
@@ -1086,6 +1212,7 @@ pub(crate) struct SelectionState {
 #[derive(Default, Debug, Clone)]
 pub(crate) struct PanState {
     pub(crate) active: bool,
+    pub(crate) button: Option<mouse::Button>,
     pub(crate) start_cursor: DVec2,
     pub(crate) start_camera_center: DVec2,
 }
@@ -1098,9 +1225,10 @@ pub(crate) struct DragState {
 #[cfg(test)]
 mod tests {
     use glam::DVec2;
+    use iced::Point;
 
     use super::*;
-    use crate::Series;
+    use crate::{PointId, Series};
 
     #[test]
     fn axes_transform_series_maps_to_camera_range_and_skips_autoscale_bounds() {
@@ -1118,5 +1246,243 @@ mod tests {
         assert_eq!(state.points[0].position, [9.0, 22.0]);
         assert_eq!(state.data_min, None);
         assert_eq!(state.data_max, None);
+    }
+
+    #[test]
+    fn arrow_keys_use_configured_pan_fraction_when_enabled_and_hovered() {
+        let mut widget = PlotWidget::new();
+        widget.controls.interaction.bind_key(
+            keyboard::Key::Named(keyboard::key::Named::ArrowRight),
+            KeyAction::PanBy {
+                direction: PanDirection::Right,
+                fraction: 0.25,
+            },
+        );
+
+        let mut state = PlotState::default();
+        state.bounds = Rectangle {
+            x: 0.0,
+            y: 0.0,
+            width: 100.0,
+            height: 100.0,
+        };
+        state.camera.position = DVec2::ZERO;
+        state.camera.half_extents = DVec2::new(10.0, 20.0);
+
+        let changed = state.handle_keyboard_event(
+            &arrow_key_event(
+                keyboard::key::Named::ArrowRight,
+                keyboard::key::Code::ArrowRight,
+            ),
+            &widget,
+            mouse::Cursor::Available(Point::new(50.0, 50.0)),
+        );
+
+        assert!(changed);
+        assert_eq!(state.camera.position, DVec2::new(5.0, 0.0));
+    }
+
+    #[test]
+    fn arrow_keys_do_not_pan_when_disabled() {
+        let mut widget = PlotWidget::new();
+        widget.controls.interaction.unbind_arrow_pan();
+
+        let mut state = PlotState::default();
+        state.bounds = Rectangle {
+            x: 0.0,
+            y: 0.0,
+            width: 100.0,
+            height: 100.0,
+        };
+        state.camera.position = DVec2::ZERO;
+        state.camera.half_extents = DVec2::new(10.0, 20.0);
+
+        let changed = state.handle_keyboard_event(
+            &arrow_key_event(keyboard::key::Named::ArrowUp, keyboard::key::Code::ArrowUp),
+            &widget,
+            mouse::Cursor::Available(Point::new(50.0, 50.0)),
+        );
+
+        assert!(!changed);
+        assert_eq!(state.camera.position, DVec2::ZERO);
+    }
+
+    #[test]
+    fn configured_mouse_button_starts_and_stops_drag_pan() {
+        let mut widget = PlotWidget::new();
+        widget
+            .controls
+            .interaction
+            .set_drag_action(DragAction::Pan, Some(mouse::Button::Middle));
+
+        let mut state = PlotState::default();
+        state.bounds = Rectangle {
+            x: 0.0,
+            y: 0.0,
+            width: 100.0,
+            height: 100.0,
+        };
+        state.cursor_position = Vec2::new(50.0, 50.0);
+
+        let mut hover_pick = None;
+        let mut drag_event = None;
+        state.handle_mouse_event(
+            Event::ButtonPressed(mouse::Button::Middle),
+            mouse::Cursor::Available(Point::new(50.0, 50.0)),
+            &widget,
+            &mut hover_pick,
+            &mut drag_event,
+        );
+
+        assert!(state.pan.active);
+        assert_eq!(state.pan.button, Some(mouse::Button::Middle));
+
+        state.handle_mouse_event(
+            Event::ButtonReleased(mouse::Button::Middle),
+            mouse::Cursor::Available(Point::new(50.0, 50.0)),
+            &widget,
+            &mut hover_pick,
+            &mut drag_event,
+        );
+
+        assert!(!state.pan.active);
+        assert_eq!(state.pan.button, None);
+    }
+
+    #[test]
+    fn left_click_picks_when_left_button_is_box_zoom() {
+        let mut widget = PlotWidget::new();
+        widget
+            .controls
+            .interaction
+            .set_drag_action(DragAction::Pan, Some(mouse::Button::Right))
+            .set_drag_action(DragAction::BoxZoom, Some(mouse::Button::Left));
+
+        let mut state = PlotState::default();
+        state.bounds = Rectangle {
+            x: 0.0,
+            y: 0.0,
+            width: 100.0,
+            height: 100.0,
+        };
+        state.cursor_position = Vec2::new(50.0, 50.0);
+
+        let point_id = PointId {
+            series_id: ShapeId::new(),
+            point_index: 0,
+        };
+        let mut hover_pick = Some(HoverPickEvent::Hover(point_id));
+        let mut drag_event = None;
+
+        state.handle_mouse_event(
+            Event::ButtonPressed(mouse::Button::Left),
+            mouse::Cursor::Available(Point::new(50.0, 50.0)),
+            &widget,
+            &mut hover_pick,
+            &mut drag_event,
+        );
+
+        state.handle_mouse_event(
+            Event::ButtonReleased(mouse::Button::Left),
+            mouse::Cursor::Available(Point::new(50.0, 50.0)),
+            &widget,
+            &mut hover_pick,
+            &mut drag_event,
+        );
+
+        assert!(matches!(hover_pick, Some(HoverPickEvent::Pick(id)) if id == point_id));
+        assert!(!state.selection.active);
+    }
+
+    #[test]
+    fn left_double_click_autoscales_when_left_button_is_box_zoom() {
+        let mut widget = PlotWidget::new();
+        widget
+            .controls
+            .interaction
+            .set_drag_action(DragAction::Pan, Some(mouse::Button::Right))
+            .set_drag_action(DragAction::BoxZoom, Some(mouse::Button::Left));
+
+        let mut state = PlotState::default();
+        state.bounds = Rectangle {
+            x: 0.0,
+            y: 0.0,
+            width: 100.0,
+            height: 100.0,
+        };
+        state.cursor_position = Vec2::new(50.0, 50.0);
+        state.data_min = Some(DVec2::new(10.0, 20.0));
+        state.data_max = Some(DVec2::new(30.0, 60.0));
+        state.camera.position = DVec2::ZERO;
+
+        let mut hover_pick = None;
+        let mut drag_event = None;
+        for _ in 0..2 {
+            state.handle_mouse_event(
+                Event::ButtonPressed(mouse::Button::Left),
+                mouse::Cursor::Available(Point::new(50.0, 50.0)),
+                &widget,
+                &mut hover_pick,
+                &mut drag_event,
+            );
+            state.handle_mouse_event(
+                Event::ButtonReleased(mouse::Button::Left),
+                mouse::Cursor::Available(Point::new(50.0, 50.0)),
+                &widget,
+                &mut hover_pick,
+                &mut drag_event,
+            );
+        }
+
+        assert_eq!(state.camera.position, DVec2::new(20.0, 40.0));
+        assert!(!state.selection.active);
+    }
+
+    #[test]
+    fn configured_key_autoscales_when_hovered() {
+        let mut widget = PlotWidget::new();
+        widget.controls.interaction.bind_key(
+            keyboard::Key::Named(keyboard::key::Named::Home),
+            KeyAction::Autoscale,
+        );
+
+        let mut state = PlotState::default();
+        state.bounds = Rectangle {
+            x: 0.0,
+            y: 0.0,
+            width: 100.0,
+            height: 100.0,
+        };
+        state.data_min = Some(DVec2::new(10.0, 20.0));
+        state.data_max = Some(DVec2::new(30.0, 60.0));
+        state.camera.position = DVec2::ZERO;
+
+        let changed = state.handle_keyboard_event(
+            &key_event(
+                keyboard::Key::Named(keyboard::key::Named::Home),
+                keyboard::key::Code::Home,
+            ),
+            &widget,
+            mouse::Cursor::Available(Point::new(50.0, 50.0)),
+        );
+
+        assert!(changed);
+        assert_eq!(state.camera.position, DVec2::new(20.0, 40.0));
+    }
+
+    fn arrow_key_event(named: keyboard::key::Named, code: keyboard::key::Code) -> keyboard::Event {
+        key_event(keyboard::Key::Named(named), code)
+    }
+
+    fn key_event(key: keyboard::Key, code: keyboard::key::Code) -> keyboard::Event {
+        keyboard::Event::KeyPressed {
+            modified_key: key.clone(),
+            key,
+            physical_key: keyboard::key::Physical::Code(code),
+            location: keyboard::Location::Standard,
+            modifiers: keyboard::Modifiers::default(),
+            text: None,
+            repeat: false,
+        }
     }
 }

--- a/src/plot_state.rs
+++ b/src/plot_state.rs
@@ -515,9 +515,10 @@ impl PlotState {
                 }
 
                 if self.drag.active
+                    && let Some(button) = self.drag.button
                     && let Some(world) = self.cursor_world_data(viewport)
                 {
-                    *publish_drag_event = Some(DragEvent::Update { world });
+                    *publish_drag_event = Some(DragEvent::Update { button, world });
                 }
 
                 // Hover picking (only when not panning or selecting)
@@ -582,7 +583,7 @@ impl PlotState {
                         self.drag.active = true;
                         self.drag.button = Some(button);
                         if let Some(world) = self.cursor_world_data(viewport) {
-                            *publish_drag_event = Some(DragEvent::Start { world });
+                            *publish_drag_event = Some(DragEvent::Start { button, world });
                         }
                     }
                 }
@@ -596,7 +597,7 @@ impl PlotState {
                     && self.drag.button == Some(button)
                     && let Some(world) = self.cursor_world_data(viewport)
                 {
-                    *publish_drag_event = Some(DragEvent::End { world });
+                    *publish_drag_event = Some(DragEvent::End { button, world });
                     self.drag.active = false;
                     self.drag.button = None;
                 }
@@ -1254,12 +1255,14 @@ mod tests {
             },
         );
 
-        let mut state = PlotState::default();
-        state.bounds = Rectangle {
-            x: 0.0,
-            y: 0.0,
-            width: 100.0,
-            height: 100.0,
+        let mut state = PlotState {
+            bounds: Rectangle {
+                x: 0.0,
+                y: 0.0,
+                width: 100.0,
+                height: 100.0,
+            },
+            ..PlotState::default()
         };
         state.camera.position = DVec2::ZERO;
         state.camera.half_extents = DVec2::new(10.0, 20.0);
@@ -1282,12 +1285,14 @@ mod tests {
         let mut widget = PlotWidget::new();
         widget.controls.unbind_arrow_pan();
 
-        let mut state = PlotState::default();
-        state.bounds = Rectangle {
-            x: 0.0,
-            y: 0.0,
-            width: 100.0,
-            height: 100.0,
+        let mut state = PlotState {
+            bounds: Rectangle {
+                x: 0.0,
+                y: 0.0,
+                width: 100.0,
+                height: 100.0,
+            },
+            ..PlotState::default()
         };
         state.camera.position = DVec2::ZERO;
         state.camera.half_extents = DVec2::new(10.0, 20.0);
@@ -1309,14 +1314,16 @@ mod tests {
             .controls
             .set_drag_action(DragAction::Pan, Some(mouse::Button::Middle));
 
-        let mut state = PlotState::default();
-        state.bounds = Rectangle {
-            x: 0.0,
-            y: 0.0,
-            width: 100.0,
-            height: 100.0,
+        let mut state = PlotState {
+            bounds: Rectangle {
+                x: 0.0,
+                y: 0.0,
+                width: 100.0,
+                height: 100.0,
+            },
+            cursor_position: Vec2::new(50.0, 50.0),
+            ..PlotState::default()
         };
-        state.cursor_position = Vec2::new(50.0, 50.0);
 
         let mut hover_pick = None;
         let mut drag_event = None;
@@ -1346,14 +1353,16 @@ mod tests {
     #[test]
     fn unbound_non_left_button_publishes_drag_events() {
         let widget = PlotWidget::new();
-        let mut state = PlotState::default();
-        state.bounds = Rectangle {
-            x: 0.0,
-            y: 0.0,
-            width: 100.0,
-            height: 100.0,
+        let mut state = PlotState {
+            bounds: Rectangle {
+                x: 0.0,
+                y: 0.0,
+                width: 100.0,
+                height: 100.0,
+            },
+            cursor_position: Vec2::new(50.0, 50.0),
+            ..PlotState::default()
         };
-        state.cursor_position = Vec2::new(50.0, 50.0);
 
         let mut hover_pick = None;
         let mut drag_event = None;
@@ -1365,7 +1374,13 @@ mod tests {
             &mut drag_event,
         );
 
-        assert!(matches!(drag_event, Some(DragEvent::Start { .. })));
+        assert!(matches!(
+            drag_event,
+            Some(DragEvent::Start {
+                button: mouse::Button::Middle,
+                ..
+            })
+        ));
         assert!(state.drag.active);
         assert_eq!(state.drag.button, Some(mouse::Button::Middle));
 
@@ -1378,7 +1393,13 @@ mod tests {
             &mut drag_event,
         );
 
-        assert!(matches!(drag_event, Some(DragEvent::End { .. })));
+        assert!(matches!(
+            drag_event,
+            Some(DragEvent::End {
+                button: mouse::Button::Middle,
+                ..
+            })
+        ));
         assert!(!state.drag.active);
         assert_eq!(state.drag.button, None);
     }
@@ -1391,14 +1412,16 @@ mod tests {
             .set_drag_action(DragAction::Pan, Some(mouse::Button::Right))
             .set_drag_action(DragAction::BoxZoom, Some(mouse::Button::Left));
 
-        let mut state = PlotState::default();
-        state.bounds = Rectangle {
-            x: 0.0,
-            y: 0.0,
-            width: 100.0,
-            height: 100.0,
+        let mut state = PlotState {
+            bounds: Rectangle {
+                x: 0.0,
+                y: 0.0,
+                width: 100.0,
+                height: 100.0,
+            },
+            cursor_position: Vec2::new(50.0, 50.0),
+            ..PlotState::default()
         };
-        state.cursor_position = Vec2::new(50.0, 50.0);
 
         let point_id = PointId {
             series_id: ShapeId::new(),
@@ -1435,16 +1458,18 @@ mod tests {
             .set_drag_action(DragAction::Pan, Some(mouse::Button::Right))
             .set_drag_action(DragAction::BoxZoom, Some(mouse::Button::Left));
 
-        let mut state = PlotState::default();
-        state.bounds = Rectangle {
-            x: 0.0,
-            y: 0.0,
-            width: 100.0,
-            height: 100.0,
+        let mut state = PlotState {
+            bounds: Rectangle {
+                x: 0.0,
+                y: 0.0,
+                width: 100.0,
+                height: 100.0,
+            },
+            cursor_position: Vec2::new(50.0, 50.0),
+            data_min: Some(DVec2::new(10.0, 20.0)),
+            data_max: Some(DVec2::new(30.0, 60.0)),
+            ..PlotState::default()
         };
-        state.cursor_position = Vec2::new(50.0, 50.0);
-        state.data_min = Some(DVec2::new(10.0, 20.0));
-        state.data_max = Some(DVec2::new(30.0, 60.0));
         state.camera.position = DVec2::ZERO;
 
         let mut hover_pick = None;
@@ -1478,15 +1503,17 @@ mod tests {
             KeyAction::Autoscale,
         );
 
-        let mut state = PlotState::default();
-        state.bounds = Rectangle {
-            x: 0.0,
-            y: 0.0,
-            width: 100.0,
-            height: 100.0,
+        let mut state = PlotState {
+            bounds: Rectangle {
+                x: 0.0,
+                y: 0.0,
+                width: 100.0,
+                height: 100.0,
+            },
+            data_min: Some(DVec2::new(10.0, 20.0)),
+            data_max: Some(DVec2::new(30.0, 60.0)),
+            ..PlotState::default()
         };
-        state.data_min = Some(DVec2::new(10.0, 20.0));
-        state.data_max = Some(DVec2::new(30.0, 60.0));
         state.camera.position = DVec2::ZERO;
 
         let changed = state.handle_keyboard_event(

--- a/src/plot_widget.rs
+++ b/src/plot_widget.rs
@@ -24,8 +24,8 @@ use iced::{
 use indexmap::IndexMap;
 
 use crate::{
-    AxisScale, DragEvent, Fill, HLine, HoverPickEvent, MarkerStyle, PlotUiMessage, PointId, Series,
-    Size, TooltipContext, Transform, VLine, axes_labels,
+    AxisScale, DragEvent, Fill, HLine, HoverPickEvent, KeyAction, MarkerStyle, PlotUiMessage,
+    PointId, Series, Size, TooltipContext, Transform, VLine, axes_labels,
     axis_link::AxisLink,
     axis_scale::plot_point_to_data,
     camera::Camera,
@@ -817,6 +817,16 @@ impl PlotWidget {
         self.controls = controls;
     }
 
+    /// Get the full interaction controls behavior for the plot.
+    pub fn get_controls(&self) -> &PlotControls {
+        &self.controls
+    }
+
+    /// Get the mutable full interaction controls behavior for the plot.
+    pub fn get_controls_mut(&mut self) -> &mut PlotControls {
+        &mut self.controls
+    }
+
     /// Set a custom formatter for the x-axis tick labels.
     /// The formatter receives a GridMark (containing the tick value and step size)
     /// and the current visible range on the x-axis.
@@ -1042,37 +1052,8 @@ impl PlotWidget {
             return None;
         }
 
-        let txt = |t| widget::text(t).size(12.0).style(widget::text::base);
-        let mut content =
-            widget::column![txt("Controls").style(widget::text::primary)].spacing(2.0);
-
-        if self.controls.pan.drag_to_pan {
-            content = content.push(txt("Left-drag: pan"));
-        }
-        if self.controls.zoom.box_zoom {
-            content = content.push(txt("Right-drag: box zoom"));
-        }
-        if self.controls.zoom.scroll_with_ctrl {
-            content = content.push(txt("Ctrl + scroll: zoom at cursor"));
-        }
-        if self.controls.pan.scroll_to_pan {
-            content = content.push(txt("Scroll: pan"));
-        }
-        if self.controls.zoom.double_click_autoscale {
-            content = content.push(txt("Double-click: reset / autoscale"));
-        }
-        if self.controls.pick.click_to_pick {
-            content = content.push(txt("Left-click point: pick"));
-        }
-        if self.controls.pick.clear_on_escape {
-            content = content.push(txt("Esc: clear picked points"));
-        }
-        if has_legend {
-            content = content.push(txt("Click icon in legend to toggle visibility."));
-        }
-
         Some(
-            container(content)
+            container(self.controls.view_controls_overlay_panel(has_legend))
                 .padding(8.0)
                 .style(|theme| self.update_style(theme).controls_panel)
                 .into(),
@@ -1463,7 +1444,7 @@ fn update_plot_program<const IS_CANVAS: bool>(
     state.bounds = bounds;
     state.hover_enabled = widget.controls.highlight_on_hover
         && (widget.hover_highlight_provider.is_some() || widget.pick_highlight_provider.is_some());
-    state.pick_enabled = widget.controls.pick.click_to_pick;
+    state.pick_enabled = widget.controls.interaction.has_pick_action();
     state.hover_radius_px = widget.hover_radius_px;
     state.crosshairs_enabled = widget.crosshairs_enabled;
 
@@ -1572,16 +1553,13 @@ fn update_plot_program<const IS_CANVAS: bool>(
             }
         }
         iced::Event::Keyboard(keyboard_event) => {
-            if let keyboard::Event::KeyPressed {
-                key: keyboard::Key::Named(keyboard::key::Named::Escape),
-                ..
-            } = keyboard_event
-                && widget.controls.pick.clear_on_escape
+            if let keyboard::Event::KeyPressed { key, .. } = keyboard_event
+                && widget.controls.interaction.key_action(key) == Some(KeyAction::ClearPick)
             {
                 effects.hover_pick = Some(HoverPickEvent::ClearPick);
                 invalidation.overlay_layer();
             }
-            effects.needs_redraw |= state.handle_keyboard_event(keyboard_event);
+            effects.needs_redraw |= state.handle_keyboard_event(keyboard_event, widget, cursor);
         }
         _ => {}
     }

--- a/src/plot_widget.rs
+++ b/src/plot_widget.rs
@@ -66,6 +66,8 @@ pub struct PlotWidget {
     // Configuration
     pub(crate) autoscale_on_updates: bool,
     pub(crate) controls: PlotControls,
+    pub(crate) highlight_on_hover: bool,
+    pub(crate) show_controls_help: bool,
     pub(crate) legend_enabled: bool,
     pub(crate) legend_collapsed: bool,
     pub(crate) x_axis_label: String,
@@ -127,6 +129,8 @@ impl PlotWidget {
             data_version: 1,
             autoscale_on_updates: false,
             controls: PlotControls::default(),
+            highlight_on_hover: true,
+            show_controls_help: true,
             legend_enabled: true,
             legend_collapsed: false,
             x_axis_label: String::new(),
@@ -827,6 +831,26 @@ impl PlotWidget {
         &mut self.controls
     }
 
+    /// Enable or disable point highlighting while hovering.
+    pub fn set_highlight_on_hover(&mut self, enabled: bool) {
+        self.highlight_on_hover = enabled;
+    }
+
+    /// Return whether point highlighting while hovering is enabled.
+    pub fn highlight_on_hover(&self) -> bool {
+        self.highlight_on_hover
+    }
+
+    /// Enable or disable the in-canvas controls/help UI (`?` button + panel).
+    pub fn set_controls_help(&mut self, enabled: bool) {
+        self.show_controls_help = enabled;
+    }
+
+    /// Return whether the in-canvas controls/help UI is enabled.
+    pub fn controls_help_enabled(&self) -> bool {
+        self.show_controls_help
+    }
+
     /// Set a custom formatter for the x-axis tick labels.
     /// The formatter receives a GridMark (containing the tick value and step size)
     /// and the current visible range on the x-axis.
@@ -1014,7 +1038,7 @@ impl PlotWidget {
     }
 
     fn view_top_right_overlay(&self, has_legend: bool) -> Element<'_, PlotUiMessage> {
-        let help_btn = self.controls.show_controls_help.then(|| {
+        let help_btn = self.show_controls_help.then(|| {
             let help_label = if self.controls_overlay_open {
                 "×"
             } else {
@@ -1442,9 +1466,9 @@ fn update_plot_program<const IS_CANVAS: bool>(
 
     // Keep these in sync early, since other phases depend on them.
     state.bounds = bounds;
-    state.hover_enabled = widget.controls.highlight_on_hover
+    state.hover_enabled = widget.highlight_on_hover
         && (widget.hover_highlight_provider.is_some() || widget.pick_highlight_provider.is_some());
-    state.pick_enabled = widget.controls.interaction.has_pick_action();
+    state.pick_enabled = widget.controls.has_pick_action();
     state.hover_radius_px = widget.hover_radius_px;
     state.crosshairs_enabled = widget.crosshairs_enabled;
 
@@ -1554,7 +1578,7 @@ fn update_plot_program<const IS_CANVAS: bool>(
         }
         iced::Event::Keyboard(keyboard_event) => {
             if let keyboard::Event::KeyPressed { key, .. } = keyboard_event
-                && widget.controls.interaction.key_action(key) == Some(KeyAction::ClearPick)
+                && widget.controls.key_action(key) == Some(KeyAction::ClearPick)
             {
                 effects.hover_pick = Some(HoverPickEvent::ClearPick);
                 invalidation.overlay_layer();

--- a/src/plot_widget_builder.rs
+++ b/src/plot_widget_builder.rs
@@ -1,10 +1,10 @@
 use std::sync::Arc;
 
-use iced::{Theme, keyboard, mouse};
+use iced::Theme;
 
 use crate::axis_link::AxisLink;
 use crate::axis_scale::AxisScale;
-use crate::controls::{DragAction, KeyAction, PlotControls};
+use crate::controls::PlotControls;
 use crate::fill::Fill;
 use crate::message::TooltipContext;
 use crate::plot_renderer::PlotRenderStrategy;
@@ -34,6 +34,7 @@ pub struct PlotWidgetBuilder {
     y_label: Option<String>,
     autoscale_on_updates: Option<bool>,
     hover_radius_px: Option<f32>,
+    highlight_on_hover: Option<bool>,
     pick_highlight_provider: Option<HighlightPointProvider>,
     hover_highlight_provider: Option<HighlightPointProvider>,
     cursor_overlay: Option<bool>,
@@ -41,6 +42,7 @@ pub struct PlotWidgetBuilder {
     crosshairs: Option<bool>,
     render_strategy: Option<PlotRenderStrategy>,
     controls: Option<PlotControls>,
+    controls_help: Option<bool>,
     disable_legend: bool,
     x_lim: Option<(f64, f64)>,
     y_lim: Option<(f64, f64)>,
@@ -100,6 +102,12 @@ impl PlotWidgetBuilder {
         self
     }
 
+    /// Enable or disable point highlighting while hovering.
+    pub fn with_highlight_on_hover(mut self, enabled: bool) -> Self {
+        self.highlight_on_hover = Some(enabled);
+        self
+    }
+
     /// Provide a custom highlighter for pick point.
     pub fn with_pick_highlight_provider<F>(mut self, provider: F) -> Self
     where
@@ -156,7 +164,7 @@ impl PlotWidgetBuilder {
     ///
     /// When controls/help UI is disabled, you still can toggle help overlay by calling `PlotWidget.update(PlotUiMessage::ToggleControlsOverlay)`
     pub fn disable_controls_help(mut self) -> Self {
-        self.controls.get_or_insert_default().show_controls_help = false;
+        self.controls_help = Some(false);
         self
     }
 
@@ -165,77 +173,6 @@ impl PlotWidgetBuilder {
     /// By default, when plot contains at least one labeled series, the legend is enabled.
     pub fn disable_legend(mut self) -> Self {
         self.disable_legend = true;
-        self
-    }
-
-    /// Disable the scroll to pan.
-    ///
-    /// Useful if your application embeds plot widget inside a scrollable container.
-    pub fn disable_scroll_to_pan(mut self) -> Self {
-        self.controls
-            .get_or_insert_default()
-            .interaction
-            .unbind_scroll(keyboard::Modifiers::NONE);
-        self
-    }
-
-    /// Set the mouse button used for drag panning.
-    ///
-    /// Passing `None` disables drag panning.
-    pub fn with_drag_to_pan(mut self, button: Option<mouse::Button>) -> Self {
-        self.controls
-            .get_or_insert_default()
-            .interaction
-            .set_drag_action(DragAction::Pan, button);
-        self
-    }
-
-    /// Disable panning by dragging.
-    pub fn disable_drag_to_pan(mut self) -> Self {
-        self.controls
-            .get_or_insert_default()
-            .interaction
-            .set_drag_action(DragAction::Pan, None);
-        self
-    }
-
-    /// Disable panning with the arrow keys.
-    pub fn disable_arrows_to_pan(mut self) -> Self {
-        self.controls
-            .get_or_insert_default()
-            .interaction
-            .unbind_arrow_pan();
-        self
-    }
-
-    /// Set the mouse button used for box zoom.
-    ///
-    /// Passing `None` disables box zoom.
-    pub fn with_box_zoom(mut self, button: Option<mouse::Button>) -> Self {
-        self.controls
-            .get_or_insert_default()
-            .interaction
-            .set_drag_action(DragAction::BoxZoom, button);
-        self
-    }
-
-    /// Disable box zoom.
-    pub fn disable_box_zoom(mut self) -> Self {
-        self.controls
-            .get_or_insert_default()
-            .interaction
-            .set_drag_action(DragAction::BoxZoom, None);
-        self
-    }
-
-    /// Set the keyboard key used to reset/autoscale the plot.
-    ///
-    /// Passing `None` disables key-triggered autoscale.
-    pub fn with_key_autoscale(mut self, key: Option<keyboard::Key>) -> Self {
-        self.controls
-            .get_or_insert_default()
-            .interaction
-            .set_key_action(KeyAction::Autoscale, key);
         self
     }
 
@@ -454,6 +391,9 @@ impl PlotWidgetBuilder {
         if let Some(controls) = self.controls {
             w.set_controls(controls);
         }
+        if let Some(enabled) = self.controls_help {
+            w.set_controls_help(enabled);
+        }
         if self.disable_legend {
             w.legend_enabled = false;
         }
@@ -463,6 +403,9 @@ impl PlotWidgetBuilder {
         }
         if let Some(r) = self.hover_radius_px {
             w.hover_radius_px(r);
+        }
+        if let Some(enabled) = self.highlight_on_hover {
+            w.set_highlight_on_hover(enabled);
         }
         if let Some(x) = self.x_label {
             w.set_x_axis_label(x);

--- a/src/plot_widget_builder.rs
+++ b/src/plot_widget_builder.rs
@@ -1,10 +1,10 @@
 use std::sync::Arc;
 
-use iced::Theme;
+use iced::{Theme, keyboard, mouse};
 
 use crate::axis_link::AxisLink;
 use crate::axis_scale::AxisScale;
-use crate::controls::PlotControls;
+use crate::controls::{DragAction, KeyAction, PlotControls};
 use crate::fill::Fill;
 use crate::message::TooltipContext;
 use crate::plot_renderer::PlotRenderStrategy;
@@ -172,7 +172,70 @@ impl PlotWidgetBuilder {
     ///
     /// Useful if your application embeds plot widget inside a scrollable container.
     pub fn disable_scroll_to_pan(mut self) -> Self {
-        self.controls.get_or_insert_default().pan.scroll_to_pan = false;
+        self.controls
+            .get_or_insert_default()
+            .interaction
+            .unbind_scroll(keyboard::Modifiers::NONE);
+        self
+    }
+
+    /// Set the mouse button used for drag panning.
+    ///
+    /// Passing `None` disables drag panning.
+    pub fn with_drag_to_pan(mut self, button: Option<mouse::Button>) -> Self {
+        self.controls
+            .get_or_insert_default()
+            .interaction
+            .set_drag_action(DragAction::Pan, button);
+        self
+    }
+
+    /// Disable panning by dragging.
+    pub fn disable_drag_to_pan(mut self) -> Self {
+        self.controls
+            .get_or_insert_default()
+            .interaction
+            .set_drag_action(DragAction::Pan, None);
+        self
+    }
+
+    /// Disable panning with the arrow keys.
+    pub fn disable_arrows_to_pan(mut self) -> Self {
+        self.controls
+            .get_or_insert_default()
+            .interaction
+            .unbind_arrow_pan();
+        self
+    }
+
+    /// Set the mouse button used for box zoom.
+    ///
+    /// Passing `None` disables box zoom.
+    pub fn with_box_zoom(mut self, button: Option<mouse::Button>) -> Self {
+        self.controls
+            .get_or_insert_default()
+            .interaction
+            .set_drag_action(DragAction::BoxZoom, button);
+        self
+    }
+
+    /// Disable box zoom.
+    pub fn disable_box_zoom(mut self) -> Self {
+        self.controls
+            .get_or_insert_default()
+            .interaction
+            .set_drag_action(DragAction::BoxZoom, None);
+        self
+    }
+
+    /// Set the keyboard key used to reset/autoscale the plot.
+    ///
+    /// Passing `None` disables key-triggered autoscale.
+    pub fn with_key_autoscale(mut self, key: Option<keyboard::Key>) -> Self {
+        self.controls
+            .get_or_insert_default()
+            .interaction
+            .set_key_action(KeyAction::Autoscale, key);
         self
     }
 


### PR DESCRIPTION
This PR replaces the previous pan/zoom/pick-specific control booleans with a more general **trigger -> action** interaction model.

Drag, scroll, click, double-click, and keyboard controls are configured separately because they flow through different event handling paths, while each trigger now maps directly to an action such as pan, box zoom, zoom-at-cursor, autoscale, pick, clear pick, or keyboard pan.

The default behavior is preserved, but controls can now be rebound without hard-coded assumptions in `PlotState`. For example, swapping pan to right-drag and box zoom to left-drag no longer breaks point picking or double-click autoscale.

As you can see. This is a large refactor. I expect the API shape, names, and ergonomics to improve through review feedback, and I would like to use this PR as the place to iterate on the final controls design :)

## Key changes

- Replace `PanControls`, `ZoomControls`, and `PickControls` with `InteractionControls`
- Add trigger -> action maps for drag, scroll, click, double-click, and keyboard input
- Add `DragAction`, `ScrollAction`, `ClickAction`, `KeyAction`, and `PanDirection`
- Make keyboard pan fraction, drag threshold, and selection padding configurable
- Update `PlotState` to dispatch mouse and keyboard events through configured actions
- Fix click, pick, and double-click autoscale behavior when drag bindings are rebound
- Add builder helpers for drag pan, box zoom, arrow-key pan, and key autoscale
- Update examples to demonstrate runtime control rebinding