### PR TITLE
fix: clip plot overlays to plot bounds

### DIFF
--- a/src/axis_link.rs
+++ b/src/axis_link.rs
@@ -24,13 +24,13 @@ impl AxisLink {
     }
 
     /// Get the current position and half extent
-    pub(crate) fn get(&self) -> (f64, f64, u64) {
+    pub fn get(&self) -> (f64, f64, u64) {
         let inner = self.inner.read().unwrap();
         (inner.position, inner.half_extent, inner.version)
     }
 
     /// Update the position and half extent, incrementing the version
-    pub(crate) fn set(&self, position: f64, half_extent: f64) {
+    pub fn set(&self, position: f64, half_extent: f64) {
         let mut inner = self.inner.write().unwrap();
         inner.position = position;
         inner.half_extent = half_extent;

--- a/src/plot_overlay.rs
+++ b/src/plot_overlay.rs
@@ -1,7 +1,7 @@
 use iced::{
     Element, Length, Point, Rectangle, Theme, Vector,
     advanced::{
-        Clipboard, Layout, Shell, Widget, layout, overlay, renderer,
+        Clipboard, Layout, Renderer as _, Shell, Widget, layout, overlay, renderer,
         widget::{Tree, tree},
     },
     alignment::{Horizontal, Vertical},
@@ -273,9 +273,11 @@ impl<Message> Widget<Message, Theme, iced::Renderer> for PositionedOverlay<'_, M
             return;
         };
         if let Some(layout) = layout.children().next() {
-            self.content
-                .as_widget()
-                .draw(tree, renderer, theme, style, layout, cursor, &viewport);
+            renderer.with_layer(viewport, |renderer| {
+                self.content
+                    .as_widget()
+                    .draw(tree, renderer, theme, style, layout, cursor, &viewport);
+            });
         }
     }
 


### PR DESCRIPTION
I fix `PlotOverlay` drawing so overlay content is clipped to the plot viewport instead of overflowing outside the plot area.

Previously, a positioned overlay could still draw beyond the plot bounds when its child element was larger than the visible plot region or placed near an edge. This change draws overlay content inside a renderer layer scoped to the computed viewport, which keeps overlay rendering constrained to the plot area while preserving the overlay's own layout.

I also make `AxisLink::get` and `AxisLink::set` public. My application needs to read and drive linked axis state externally, so this exposes the existing synchronization primitive without changing its behavior.

Demo:

```rust
use iced::{
    Element, Length,
    widget::{Space, column, container},
};
use iced_plot::{PlotOverlay, PlotUiMessage, PlotWidget, PlotWidgetBuilder, Transform};

fn main() -> iced::Result {
    iced::application(new, update, view)
        .font(include_bytes!("fonts/FiraCodeNerdFont-Regular.ttf"))
        .default_font(iced::Font::with_name("FiraCode Nerd Font"))
        .run()
}

fn update(widget: &mut PlotWidget, message: PlotUiMessage) {
    widget.update(message);
}

fn view(widget: &PlotWidget) -> Element<'_, PlotUiMessage> {
    let plot = widget.view_with_shapes(
        std::iter::once(
            PlotOverlay::new(
                container(Space::new())
                    .align_bottom(200)
                    .center_x(4000)
                    .style(container::danger),
                [0.5, 1.0],
            )
            .with_transform_x(Transform::axes())
            .align_to_anchor(
                iced::alignment::Horizontal::Center,
                iced::alignment::Vertical::Top,
            ),
        ),
        core::iter::empty(),
        |msg| msg,
    );
    column!(
        container("other elements")
            .height(40)
            .width(Length::Fill)
            .style(container::success),
        container(plot).padding(8)
    )
    .into()
}

fn new() -> PlotWidget {
    PlotWidgetBuilder::new()
        .with_x_lim(0.0, 15.0)
        .with_y_lim(0.0, 2.0)
        .build()
        .unwrap()
}
```

Before:

https://github.com/user-attachments/assets/e8904597-2a57-4240-99ab-81b1fb6df932

Now:

https://github.com/user-attachments/assets/a52c0434-25ce-4a8e-888f-40bb6061da63




