### PR TITLE
fix: constrain plot input to visible viewport

### DIFF
--- a/src/plot_state.rs
+++ b/src/plot_state.rs
@@ -457,6 +457,40 @@ impl PlotState {
         self.point_inside(self.cursor_position.x, self.cursor_position.y)
     }
 
+    fn cursor_local_position(&self, cursor: mouse::Cursor, allow_levitating: bool) -> Option<Vec2> {
+        let position = match cursor {
+            mouse::Cursor::Available(position) => position,
+            mouse::Cursor::Levitating(position) if allow_levitating => position,
+            mouse::Cursor::Levitating(_) | mouse::Cursor::Unavailable => return None,
+        };
+
+        Some(Vec2::new(
+            position.x - self.bounds.x,
+            position.y - self.bounds.y,
+        ))
+    }
+
+    fn available_cursor_local_position_inside(&self, cursor: mouse::Cursor) -> Option<Vec2> {
+        let position = self.cursor_local_position(cursor, false)?;
+        self.point_inside(position.x, position.y)
+            .then_some(position)
+    }
+
+    pub(crate) fn available_cursor_is_inside(&self, cursor: mouse::Cursor) -> bool {
+        self.available_cursor_local_position_inside(cursor)
+            .is_some()
+    }
+
+    pub(crate) fn drag_in_progress(&self) -> bool {
+        self.pan.active || self.selection.active || self.drag.active
+    }
+
+    fn drag_in_progress_for(&self, button: mouse::Button) -> bool {
+        (self.pan.active && self.pan.button == Some(button))
+            || (self.selection.active && self.selection.button == Some(button))
+            || (self.drag.active && self.drag.button == Some(button))
+    }
+
     pub(crate) fn handle_mouse_event(
         &mut self,
         event: Event,
@@ -472,17 +506,18 @@ impl PlotState {
         let viewport: DVec2 = Vec2::new(self.bounds.width, self.bounds.height).into();
 
         match event {
-            Event::CursorMoved { mut position } => {
-                if let mouse::Cursor::Available(p) | mouse::Cursor::Levitating(p) = cursor {
-                    // cursor position can consider the scrolled offset
-                    position = p;
-                }
-                // Check if the cursor is inside this widget's bounds in window space
+            Event::CursorMoved { .. } => {
+                let Some(position) = self.cursor_local_position(cursor, self.drag_in_progress())
+                else {
+                    if self.picking.last_hover_cache.is_some() {
+                        self.picking.last_hover_cache = None;
+                        needs_redraw = true;
+                    }
+                    return needs_redraw;
+                };
                 let inside = self.point_inside(position.x, position.y);
 
-                // Store cursor in local coordinates (relative to bounds)
-                self.cursor_position =
-                    Vec2::new(position.x - self.bounds.x, position.y - self.bounds.y);
+                self.cursor_position = position;
                 // Update crosshairs position when enabled
                 if widget.crosshairs_enabled {
                     self.crosshairs_position = self.cursor_position;
@@ -548,10 +583,12 @@ impl PlotState {
             Event::ButtonPressed(button) => {
                 // Only start button-driven interactions when the press starts
                 // inside our bounds. Drags continue even if the cursor leaves.
-                let inside = self.cursor_inside();
-                if !inside {
+                let Some(cursor_position) = self.available_cursor_local_position_inside(cursor)
+                else {
                     return needs_redraw;
-                }
+                };
+
+                self.cursor_position = cursor_position;
 
                 self.press.active = true;
                 self.press.button = Some(button);
@@ -589,7 +626,26 @@ impl PlotState {
                 }
             }
             Event::ButtonReleased(button) => {
-                let click_candidate = self.press.button == Some(button)
+                let drag_release = self.drag_in_progress_for(button);
+                let release_position_available = if let Some(cursor_position) = if drag_release {
+                    self.cursor_local_position(cursor, true)
+                } else {
+                    self.available_cursor_local_position_inside(cursor)
+                } {
+                    self.cursor_position = cursor_position;
+                    true
+                } else if !drag_release {
+                    if self.press.button == Some(button) {
+                        self.press.active = false;
+                        self.press.button = None;
+                    }
+                    return needs_redraw;
+                } else {
+                    false
+                };
+
+                let click_candidate = release_position_available
+                    && self.press.button == Some(button)
                     && (self.cursor_position - self.press.start).length()
                         <= widget.controls.drag_delta_threshold();
 
@@ -655,10 +711,12 @@ impl PlotState {
             }
             Event::WheelScrolled { delta } => {
                 // Only respond to wheel when cursor is inside our bounds
-                let inside = self.cursor_inside();
-                if !inside {
+                let Some(cursor_position) = self.available_cursor_local_position_inside(cursor)
+                else {
                     return needs_redraw;
-                }
+                };
+
+                self.cursor_position = cursor_position;
 
                 let (x, y) = match delta {
                     iced::mouse::ScrollDelta::Lines { x, y } => (x, y),
@@ -696,11 +754,14 @@ impl PlotState {
         widget: &PlotWidget,
         cursor: mouse::Cursor,
     ) -> bool {
-        if let keyboard::Event::ModifiersChanged(modifiers) = event {
-            self.modifiers = *modifiers;
-        }
+        let cursor_over = self.available_cursor_is_inside(cursor);
 
-        let cursor_over = cursor.is_over(self.bounds);
+        if let keyboard::Event::ModifiersChanged(modifiers) = event {
+            if cursor_over {
+                self.modifiers = *modifiers;
+            }
+            return false;
+        }
 
         let keyboard::Event::KeyPressed { key, .. } = event else {
             return false;
@@ -1348,6 +1409,229 @@ mod tests {
 
         assert!(!state.pan.active);
         assert_eq!(state.pan.button, None);
+    }
+
+    #[test]
+    fn levitating_cursor_does_not_start_drag_pan() {
+        let widget = PlotWidget::new();
+        let mut state = PlotState {
+            bounds: Rectangle {
+                x: 0.0,
+                y: 100.0,
+                width: 100.0,
+                height: 300.0,
+            },
+            cursor_position: Vec2::new(50.0, 50.0),
+            ..PlotState::default()
+        };
+
+        let mut hover_pick = None;
+        let mut drag_event = None;
+        state.handle_mouse_event(
+            Event::ButtonPressed(mouse::Button::Left),
+            mouse::Cursor::Levitating(Point::new(50.0, 350.0)),
+            &widget,
+            &mut hover_pick,
+            &mut drag_event,
+        );
+
+        assert!(!state.pan.active);
+        assert_eq!(state.pan.button, None);
+    }
+
+    #[test]
+    fn levitating_cursor_continues_active_drag_pan() {
+        let widget = PlotWidget::new();
+        let mut state = PlotState {
+            bounds: Rectangle {
+                x: 0.0,
+                y: 100.0,
+                width: 100.0,
+                height: 300.0,
+            },
+            ..PlotState::default()
+        };
+        state.camera.position = DVec2::ZERO;
+        state.camera.half_extents = DVec2::new(10.0, 30.0);
+
+        let mut hover_pick = None;
+        let mut drag_event = None;
+        state.handle_mouse_event(
+            Event::ButtonPressed(mouse::Button::Left),
+            mouse::Cursor::Available(Point::new(50.0, 150.0)),
+            &widget,
+            &mut hover_pick,
+            &mut drag_event,
+        );
+
+        state.handle_mouse_event(
+            Event::CursorMoved {
+                position: Point::new(50.0, 450.0),
+            },
+            mouse::Cursor::Levitating(Point::new(50.0, 450.0)),
+            &widget,
+            &mut hover_pick,
+            &mut drag_event,
+        );
+
+        assert!(state.pan.active);
+        assert_eq!(state.cursor_position, Vec2::new(50.0, 350.0));
+        assert_ne!(state.camera.position, DVec2::ZERO);
+    }
+
+    #[test]
+    fn levitating_cursor_does_not_scroll_pan() {
+        let widget = PlotWidget::new();
+        let mut state = PlotState {
+            bounds: Rectangle {
+                x: 0.0,
+                y: 100.0,
+                width: 100.0,
+                height: 300.0,
+            },
+            cursor_position: Vec2::new(50.0, 50.0),
+            ..PlotState::default()
+        };
+        state.camera.position = DVec2::ZERO;
+        state.camera.half_extents = DVec2::new(10.0, 30.0);
+
+        let mut hover_pick = None;
+        let mut drag_event = None;
+        state.handle_mouse_event(
+            Event::WheelScrolled {
+                delta: mouse::ScrollDelta::Lines { x: 0.0, y: 1.0 },
+            },
+            mouse::Cursor::Levitating(Point::new(50.0, 350.0)),
+            &widget,
+            &mut hover_pick,
+            &mut drag_event,
+        );
+
+        assert_eq!(state.camera.position, DVec2::ZERO);
+    }
+
+    #[test]
+    fn levitating_cursor_does_not_release_click() {
+        let widget = PlotWidget::new();
+        let point_id = PointId {
+            series_id: ShapeId::new(),
+            point_index: 0,
+        };
+        let mut state = PlotState {
+            bounds: Rectangle {
+                x: 0.0,
+                y: 100.0,
+                width: 100.0,
+                height: 300.0,
+            },
+            cursor_position: Vec2::new(50.0, 50.0),
+            press: ButtonPressState {
+                active: true,
+                button: Some(mouse::Button::Left),
+                start: Vec2::new(50.0, 50.0),
+            },
+            ..PlotState::default()
+        };
+
+        let mut hover_pick = Some(HoverPickEvent::Hover(point_id));
+        let mut drag_event = None;
+        state.handle_mouse_event(
+            Event::ButtonReleased(mouse::Button::Left),
+            mouse::Cursor::Levitating(Point::new(50.0, 350.0)),
+            &widget,
+            &mut hover_pick,
+            &mut drag_event,
+        );
+
+        assert!(matches!(hover_pick, Some(HoverPickEvent::Hover(id)) if id == point_id));
+        assert!(!state.press.active);
+    }
+
+    #[test]
+    fn available_cursor_uses_absolute_bounds_for_drag_start() {
+        let widget = PlotWidget::new();
+        let mut state = PlotState {
+            bounds: Rectangle {
+                x: 0.0,
+                y: 100.0,
+                width: 100.0,
+                height: 300.0,
+            },
+            ..PlotState::default()
+        };
+
+        let mut hover_pick = None;
+        let mut drag_event = None;
+        state.handle_mouse_event(
+            Event::ButtonPressed(mouse::Button::Left),
+            mouse::Cursor::Available(Point::new(50.0, 350.0)),
+            &widget,
+            &mut hover_pick,
+            &mut drag_event,
+        );
+
+        assert!(state.pan.active);
+        assert_eq!(state.pan.button, Some(mouse::Button::Left));
+        assert_eq!(state.cursor_position, Vec2::new(50.0, 250.0));
+    }
+
+    #[test]
+    fn levitating_cursor_does_not_enable_keyboard_pan() {
+        let mut widget = PlotWidget::new();
+        widget.controls.bind_key(
+            keyboard::Key::Named(keyboard::key::Named::ArrowRight),
+            KeyAction::PanBy {
+                direction: PanDirection::Right,
+                fraction: 0.25,
+            },
+        );
+
+        let mut state = PlotState {
+            bounds: Rectangle {
+                x: 0.0,
+                y: 100.0,
+                width: 100.0,
+                height: 300.0,
+            },
+            ..PlotState::default()
+        };
+        state.camera.position = DVec2::ZERO;
+        state.camera.half_extents = DVec2::new(10.0, 20.0);
+
+        let changed = state.handle_keyboard_event(
+            &arrow_key_event(
+                keyboard::key::Named::ArrowRight,
+                keyboard::key::Code::ArrowRight,
+            ),
+            &widget,
+            mouse::Cursor::Levitating(Point::new(50.0, 350.0)),
+        );
+
+        assert!(!changed);
+        assert_eq!(state.camera.position, DVec2::ZERO);
+    }
+
+    #[test]
+    fn levitating_cursor_does_not_update_keyboard_modifiers() {
+        let widget = PlotWidget::new();
+        let mut state = PlotState {
+            bounds: Rectangle {
+                x: 0.0,
+                y: 100.0,
+                width: 100.0,
+                height: 300.0,
+            },
+            modifiers: keyboard::Modifiers::NONE,
+            ..PlotState::default()
+        };
+
+        state.handle_keyboard_event(
+            &keyboard::Event::ModifiersChanged(keyboard::Modifiers::CTRL),
+            &widget,
+            mouse::Cursor::Levitating(Point::new(50.0, 350.0)),
+        );
+
+        assert_eq!(state.modifiers, keyboard::Modifiers::NONE);
     }
 
     #[test]

--- a/src/plot_widget.rs
+++ b/src/plot_widget.rs
@@ -1565,8 +1565,15 @@ fn update_plot_program<const IS_CANVAS: bool>(
 
             match mouse_event {
                 iced::mouse::Event::CursorMoved { .. } => {
-                    maybe_submit_hover_request(widget, state, &mut effects);
-                    update_cursor_overlay_on_move(widget, state, &mut effects);
+                    if state.available_cursor_is_inside(cursor) {
+                        maybe_submit_hover_request(widget, state, &mut effects);
+                        update_cursor_overlay_on_move(widget, state, &mut effects);
+                    } else {
+                        clear_hover_effect(widget, state, &mut effects);
+                        if widget.cursor_overlay {
+                            effects.clear_cursor_position = true;
+                        }
+                    }
                     invalidation.overlay_layer();
                 }
                 iced::mouse::Event::CursorLeft => {
@@ -1578,6 +1585,7 @@ fn update_plot_program<const IS_CANVAS: bool>(
         }
         iced::Event::Keyboard(keyboard_event) => {
             if let keyboard::Event::KeyPressed { key, .. } = keyboard_event
+                && state.available_cursor_is_inside(cursor)
                 && widget.controls.key_action(key) == Some(KeyAction::ClearPick)
             {
                 effects.hover_pick = Some(HoverPickEvent::ClearPick);


### PR DESCRIPTION
Fixes PlotWidget's input action trigger when only part of the widget is visible.

Previously, clipped plot regions could still receive input because `Cursor::Levitating` was treated as an active cursor position. This allowed interactions like pan, wheel pan/zoom, hover, click, and keyboard actions to trigger outside the visible viewport.

This PR updates input gating so that:

- mouse and keyboard events only apply when the cursor is inside the visible viewport
- `Cursor::Levitating` cannot start interactions
- active drags (include pan, box-zoom) continue after leaving the viewport
- hover/cursor overlay state is cleared when the cursor leaves the visible viewport
- keyboard shortcuts and modifier updates are ignored outside the visible viewport

## Demo

```rust
use iced::widget::{column, container, scrollable};
use iced::{Element, Length};
use iced_plot::{Color, LineStyle, PlotUiMessage, PlotWidget, PlotWidgetBuilder, Series};

fn main() -> iced::Result {
    iced::application(new, update, view)
        .font(include_bytes!("fonts/FiraCodeNerdFont-Regular.ttf"))
        .default_font(iced::Font::with_name("FiraCode Nerd Font"))
        .run()
}

fn update(widget: &mut PlotWidget, message: PlotUiMessage) {
    widget.update(message);
}

fn view(widget: &PlotWidget) -> Element<'_, PlotUiMessage> {
    column![
        container("top blank")
            .style(container::success)
            .height(100)
            .width(Length::Fill),
        container(scrollable(container(widget.view()).height(300))).height(200),
        container("bottom blank")
            .style(container::success)
            .height(100)
            .width(Length::Fill),
    ]
    .into()
}

fn new() -> PlotWidget {
    let positions = (0..100)
        .map(|i| {
            let x = i as f64 * 0.1;
            [x, x.sin()]
        })
        .collect();

    let series = Series::line_only(positions, LineStyle::solid())
        .with_label("sine")
        .with_color(Color::from_rgb(0.2, 0.5, 0.9));

    PlotWidgetBuilder::new().add_series(series).build().unwrap()
}
```
Before:

https://github.com/user-attachments/assets/a98d8dc8-d924-474a-b757-14b22c67d713

Now:

https://github.com/user-attachments/assets/df89f860-72ac-490e-a9a4-4177afbb2bcd

