### PR TITLE
fix: improve shader and canvas backend parity

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,7 @@ rand_distr = "0.6"
 [[example]]
 name              = "auto_backend"
 required-features = ["canvas"]
+
+[[example]]
+name              = "backends"
+required-features = ["canvas"]

--- a/examples/backends.rs
+++ b/examples/backends.rs
@@ -1,0 +1,116 @@
+//! Compare marker rendering between the shader and canvas backends.
+
+use iced::{
+    Element, Length,
+    widget::{column, container, row, text},
+};
+use iced_plot::{
+    Color, MarkerStyle, PlotRenderStrategy, PlotUiMessage, PlotWidget, PlotWidgetBuilder, Series,
+};
+
+const MARKER_SIZE: f32 = 48.0;
+
+fn main() -> iced::Result {
+    iced::application(App::new, App::update, App::view)
+        .font(include_bytes!("fonts/FiraCodeNerdFont-Regular.ttf"))
+        .default_font(iced::Font::with_name("FiraCode Nerd Font"))
+        .run()
+}
+
+struct App {
+    plot_a: PlotWidget,
+    plot_b: PlotWidget,
+}
+
+#[derive(Debug, Clone)]
+enum Message {
+    PlotA(PlotUiMessage),
+    PlotB(PlotUiMessage),
+}
+
+impl App {
+    fn new() -> Self {
+        Self {
+            plot_a: marker_plot(PlotRenderStrategy::Shader),
+            plot_b: marker_plot(PlotRenderStrategy::Canvas),
+        }
+    }
+
+    fn update(&mut self, message: Message) {
+        match message {
+            Message::PlotA(message) => self.plot_a.update(message),
+            Message::PlotB(message) => self.plot_b.update(message),
+        }
+    }
+
+    fn view(&self) -> Element<'_, Message> {
+        row![
+            plot_panel("Shader Plot:", self.plot_a.view().map(Message::PlotA)),
+            plot_panel("Canvas Plot:", self.plot_b.view().map(Message::PlotB)),
+        ]
+        .spacing(12)
+        .padding(12)
+        .width(Length::Fill)
+        .height(Length::Fill)
+        .into()
+    }
+}
+
+fn plot_panel<'a>(title: &'static str, plot: Element<'a, Message>) -> Element<'a, Message> {
+    column![
+        text(title).size(18),
+        container(plot).width(Length::Fill).height(Length::Fill),
+    ]
+    .spacing(8)
+    .width(Length::Fill)
+    .height(Length::Fill)
+    .into()
+}
+
+fn marker_plot(strategy: PlotRenderStrategy) -> PlotWidget {
+    let markers = [
+        (
+            "circle",
+            MarkerStyle::circle(MARKER_SIZE),
+            Color::from_rgb(0.25, 0.50, 0.95),
+        ),
+        (
+            "ring",
+            MarkerStyle::ring(MARKER_SIZE),
+            Color::from_rgb(0.10, 0.70, 0.45),
+        ),
+        (
+            "square",
+            MarkerStyle::square(MARKER_SIZE),
+            Color::from_rgb(0.90, 0.55, 0.10),
+        ),
+        (
+            "star",
+            MarkerStyle::star(MARKER_SIZE),
+            Color::from_rgb(0.95, 0.25, 0.15),
+        ),
+        (
+            "triangle",
+            MarkerStyle::triangle(MARKER_SIZE),
+            Color::from_rgb(0.60, 0.35, 0.90),
+        ),
+    ];
+
+    let mut builder = PlotWidgetBuilder::new()
+        .with_render_strategy(strategy)
+        .with_x_label("x")
+        .with_y_label("y")
+        .with_x_lim(-1.0, 1.0)
+        .with_y_lim(-0.75, markers.len() as f64 - 0.25)
+        .disable_controls_help();
+
+    for (index, (label, style, color)) in markers.into_iter().enumerate() {
+        let y = markers.len() as f64 - 1.0 - index as f64;
+        let series = Series::markers_only(vec![[0.0, y]], style)
+            .with_label(label)
+            .with_color(color);
+        builder = builder.add_series(series);
+    }
+
+    builder.build().unwrap()
+}

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -26,6 +26,7 @@ impl Grid {
         device: &Device,
         format: TextureFormat,
         camera_bgl: &BindGroupLayout,
+        sample_count: u32,
     ) {
         if self.pipeline.is_some() {
             return;
@@ -82,7 +83,7 @@ impl Grid {
             },
             depth_stencil: None,
             multisample: MultisampleState {
-                count: 1,
+                count: sample_count,
                 mask: !0,
                 alpha_to_coverage_enabled: false,
             },

--- a/src/plot_renderer/canvas.rs
+++ b/src/plot_renderer/canvas.rs
@@ -16,6 +16,8 @@ use iced::{
     widget::canvas::{self, Frame, Geometry},
 };
 
+const GRID_STROKE_WIDTH: f32 = 0.5;
+
 fn rgba_to_color(rgba: [f32; 4]) -> Color {
     Color::from_rgba(rgba[0], rgba[1], rgba[2], rgba[3])
 }
@@ -85,7 +87,12 @@ fn draw_grid(frame: &mut Frame, state: &PlotState, bounds: Rectangle) {
             iced::Point::new(tick.screen_pos, 0.0),
             iced::Point::new(tick.screen_pos, bounds.height),
         );
-        frame.stroke(&line, canvas::Stroke::default().with_color(color));
+        frame.stroke(
+            &line,
+            canvas::Stroke::default()
+                .with_width(GRID_STROKE_WIDTH)
+                .with_color(color),
+        );
     }
 
     for tick in &state.y_ticks {
@@ -98,7 +105,12 @@ fn draw_grid(frame: &mut Frame, state: &PlotState, bounds: Rectangle) {
             iced::Point::new(0.0, tick.screen_pos),
             iced::Point::new(bounds.width, tick.screen_pos),
         );
-        frame.stroke(&line, canvas::Stroke::default().with_color(color));
+        frame.stroke(
+            &line,
+            canvas::Stroke::default()
+                .with_width(GRID_STROKE_WIDTH)
+                .with_color(color),
+        );
     }
 }
 
@@ -324,7 +336,7 @@ fn draw_highlights(frame: &mut Frame, state: &PlotState, bounds: Rectangle) {
         }
 
         let center = world_to_canvas_point(plot_pos, &state.camera, &bounds);
-        let size = marker_style.size.to_px(&state.camera, &bounds) + mask_padding;
+        let size = marker_style.size.to_px(&state.camera, &bounds) * 0.5 + mask_padding;
         let rect = canvas::Path::rectangle(
             iced::Point::new(center.x - size, center.y - size),
             iced::Size::new(size * 2.0, size * 2.0),
@@ -426,8 +438,9 @@ fn draw_marker(
     let path = marker_path(center, radius, marker_type);
     match marker_type {
         MarkerType::EmptyCircle => {
+            let ring_path = canvas::Path::circle(center, radius * 0.85);
             frame.stroke(
-                &path,
+                &ring_path,
                 canvas::Stroke::default()
                     .with_width((radius * 0.3).max(1.0))
                     .with_color(color),
@@ -526,9 +539,15 @@ fn marker_path(center: iced::Point, radius: f32, marker_type: MarkerType) -> can
             iced::Size::new(radius * 2.0, radius * 2.0),
         ),
         MarkerType::Triangle => canvas::Path::new(|builder| {
-            builder.move_to(iced::Point::new(center.x, center.y - radius));
-            builder.line_to(iced::Point::new(center.x + radius, center.y + radius));
-            builder.line_to(iced::Point::new(center.x - radius, center.y + radius));
+            builder.move_to(iced::Point::new(center.x, center.y - radius * 0.866));
+            builder.line_to(iced::Point::new(
+                center.x + radius,
+                center.y + radius * 0.866,
+            ));
+            builder.line_to(iced::Point::new(
+                center.x - radius,
+                center.y + radius * 0.866,
+            ));
             builder.close();
         }),
         MarkerType::Star => canvas::Path::new(|builder| {

--- a/src/plot_renderer/shader.rs
+++ b/src/plot_renderer/shader.rs
@@ -10,11 +10,73 @@ use crate::{LineType, Size, camera::CameraUniform, grid::Grid, plot_state::PlotS
 use iced::widget::shader::Viewport;
 use iced::{Rectangle, wgpu::*};
 
+const MSAA_SAMPLE_COUNT: u32 = 4;
+
 pub struct RenderParams<'a> {
     pub encoder: &'a mut CommandEncoder,
     pub target: &'a TextureView,
     /// clip_bounds considers crop in scrollable viewport
     pub clip_bounds: &'a Rectangle<u32>,
+}
+
+fn msaa_state() -> MultisampleState {
+    MultisampleState {
+        count: MSAA_SAMPLE_COUNT,
+        mask: !0,
+        alpha_to_coverage_enabled: false,
+    }
+}
+
+fn create_color_texture(
+    device: &Device,
+    label: &'static str,
+    width: u32,
+    height: u32,
+    sample_count: u32,
+    format: TextureFormat,
+    usage: TextureUsages,
+) -> Texture {
+    device.create_texture(&TextureDescriptor {
+        label: Some(label),
+        size: Extent3d {
+            width,
+            height,
+            depth_or_array_layers: 1,
+        },
+        mip_level_count: 1,
+        sample_count,
+        dimension: TextureDimension::D2,
+        format,
+        usage,
+        view_formats: &[],
+    })
+}
+
+fn msaa_attachment<'a>(
+    targets: &'a MsaaTargets,
+    load: LoadOp<Color>,
+) -> RenderPassColorAttachment<'a> {
+    RenderPassColorAttachment {
+        view: &targets.msaa_view,
+        resolve_target: Some(&targets.resolved_view),
+        ops: Operations {
+            load,
+            store: StoreOp::Store,
+        },
+        depth_slice: None,
+    }
+}
+
+fn target_attachment(target: &TextureView) -> RenderPassColorAttachment<'_> {
+    RenderPassColorAttachment {
+        view: target,
+        resolve_target: None,
+        ops: Operations {
+            load: LoadOp::Load,
+            store: StoreOp::Store,
+        },
+        depth_slice: None,
+    }
 }
 
 #[derive(Default, Clone)]
@@ -69,6 +131,7 @@ struct PipelineCache {
     fill: Option<RenderPipeline>,
     overlay: Option<RenderPipeline>,
     line_overlay: Option<RenderPipeline>,
+    composite: Option<RenderPipeline>,
 }
 
 impl PipelineCache {
@@ -79,8 +142,19 @@ impl PipelineCache {
             fill: None,
             overlay: None,
             line_overlay: None,
+            composite: None,
         }
     }
+}
+
+struct MsaaTargets {
+    width: u32,
+    height: u32,
+    _msaa_texture: Texture,
+    msaa_view: TextureView,
+    _resolved_texture: Texture,
+    resolved_view: TextureView,
+    composite_bind_group: BindGroup,
 }
 
 /// Cache for vertex buffers
@@ -199,6 +273,9 @@ pub struct PlotRenderer {
     camera_buffer: Buffer,
     camera_bind_group: BindGroup,
     camera_bgl: BindGroupLayout,
+    composite_bgl: BindGroupLayout,
+    composite_sampler: Sampler,
+    msaa_targets: Option<MsaaTargets>,
     // Caches
     pipelines: PipelineCache,
     buffers: BufferCache,
@@ -241,11 +318,45 @@ impl PlotRenderer {
                 resource: camera_buffer.as_entire_binding(),
             }],
         });
+        let composite_bgl = device.create_bind_group_layout(&BindGroupLayoutDescriptor {
+            label: Some("plot composite bgl"),
+            entries: &[
+                BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: ShaderStages::FRAGMENT,
+                    ty: BindingType::Texture {
+                        sample_type: TextureSampleType::Float { filterable: false },
+                        view_dimension: TextureViewDimension::D2,
+                        multisampled: false,
+                    },
+                    count: None,
+                },
+                BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: ShaderStages::FRAGMENT,
+                    ty: BindingType::Sampler(SamplerBindingType::NonFiltering),
+                    count: None,
+                },
+            ],
+        });
+        let composite_sampler = device.create_sampler(&SamplerDescriptor {
+            label: Some("plot composite sampler"),
+            address_mode_u: AddressMode::ClampToEdge,
+            address_mode_v: AddressMode::ClampToEdge,
+            address_mode_w: AddressMode::ClampToEdge,
+            mag_filter: FilterMode::Nearest,
+            min_filter: FilterMode::Nearest,
+            mipmap_filter: FilterMode::Nearest,
+            ..SamplerDescriptor::default()
+        });
         Self {
             format,
             camera_buffer,
             camera_bind_group,
             camera_bgl,
+            composite_bgl,
+            composite_sampler,
+            msaa_targets: None,
             pipelines: PipelineCache::new(),
             buffers: BufferCache::new(),
             versions: VersionTracker::new(),
@@ -306,7 +417,7 @@ impl PlotRenderer {
     ) {
         self.ensure_marker_pipeline(device);
         self.grid
-            .ensure_pipeline(device, self.format, &self.camera_bgl);
+            .ensure_pipeline(device, self.format, &self.camera_bgl, MSAA_SAMPLE_COUNT);
         self.grid.update(device, state);
         if !state.fills.is_empty() {
             self.ensure_fill_pipeline(device);
@@ -319,6 +430,7 @@ impl PlotRenderer {
         }
         self.ensure_overlay_pipeline(device);
         self.ensure_line_overlay_pipeline(device);
+        self.ensure_composite_pipeline(device);
     }
     fn set_bounds(&mut self, w: u32, h: u32) {
         self.bounds_w = w;
@@ -326,6 +438,66 @@ impl PlotRenderer {
     }
     fn set_scale_factor(&mut self, scale: f32) {
         self.scale_factor = scale;
+    }
+
+    fn ensure_msaa_targets(&mut self, device: &Device, width: u32, height: u32) {
+        let width = width.max(1);
+        let height = height.max(1);
+
+        if self
+            .msaa_targets
+            .as_ref()
+            .is_some_and(|targets| targets.width == width && targets.height == height)
+        {
+            return;
+        }
+
+        let msaa_texture = create_color_texture(
+            device,
+            "iced_plot msaa color",
+            width,
+            height,
+            MSAA_SAMPLE_COUNT,
+            self.format,
+            TextureUsages::RENDER_ATTACHMENT,
+        );
+        let msaa_view = msaa_texture.create_view(&TextureViewDescriptor::default());
+
+        let resolved_texture = create_color_texture(
+            device,
+            "iced_plot resolved color",
+            width,
+            height,
+            1,
+            self.format,
+            TextureUsages::RENDER_ATTACHMENT | TextureUsages::TEXTURE_BINDING,
+        );
+        let resolved_view = resolved_texture.create_view(&TextureViewDescriptor::default());
+
+        let composite_bind_group = device.create_bind_group(&BindGroupDescriptor {
+            label: Some("plot composite bind group"),
+            layout: &self.composite_bgl,
+            entries: &[
+                BindGroupEntry {
+                    binding: 0,
+                    resource: BindingResource::TextureView(&resolved_view),
+                },
+                BindGroupEntry {
+                    binding: 1,
+                    resource: BindingResource::Sampler(&self.composite_sampler),
+                },
+            ],
+        });
+
+        self.msaa_targets = Some(MsaaTargets {
+            width,
+            height,
+            _msaa_texture: msaa_texture,
+            msaa_view,
+            _resolved_texture: resolved_texture,
+            resolved_view,
+            composite_bind_group,
+        });
     }
 
     fn sync(&mut self, device: &Device, queue: &Queue, state: &PlotState) {
@@ -381,9 +553,11 @@ impl PlotRenderer {
         let scale_factor = viewport.scale_factor();
         let bounds_width = (bounds.width * scale_factor) as u32;
         let bounds_height = (bounds.height * scale_factor) as u32;
+        let viewport_size = viewport.physical_size();
 
         self.set_bounds(bounds_width, bounds_height);
         self.set_scale_factor(scale_factor);
+        self.ensure_msaa_targets(device, viewport_size.width, viewport_size.height);
 
         // Sync picking viewport
         self.picking
@@ -500,7 +674,7 @@ impl PlotRenderer {
                 conservative: false,
             },
             depth_stencil: None,
-            multisample: MultisampleState::default(),
+            multisample: msaa_state(),
             multiview: None,
             cache: None,
         });
@@ -610,7 +784,7 @@ impl PlotRenderer {
                 conservative: false,
             },
             depth_stencil: None,
-            multisample: MultisampleState::default(),
+            multisample: msaa_state(),
             multiview: None,
             cache: None,
         });
@@ -671,7 +845,7 @@ impl PlotRenderer {
                 conservative: false,
             },
             depth_stencil: None,
-            multisample: MultisampleState::default(),
+            multisample: msaa_state(),
             multiview: None,
             cache: None,
         });
@@ -733,7 +907,7 @@ impl PlotRenderer {
                 conservative: false,
             },
             depth_stencil: None,
-            multisample: MultisampleState::default(),
+            multisample: msaa_state(),
             multiview: None,
             cache: None,
         });
@@ -794,11 +968,68 @@ impl PlotRenderer {
                 conservative: false,
             },
             depth_stencil: None,
-            multisample: MultisampleState::default(),
+            multisample: msaa_state(),
             multiview: None,
             cache: None,
         });
         self.pipelines.line_overlay = Some(pipeline);
+    }
+
+    fn ensure_composite_pipeline(&mut self, device: &Device) {
+        if self.pipelines.composite.is_some() {
+            return;
+        }
+        let shader = device.create_shader_module(include_wgsl!("../shaders/composite.wgsl"));
+        let layout = device.create_pipeline_layout(&PipelineLayoutDescriptor {
+            label: Some("plot composite layout"),
+            bind_group_layouts: &[&self.composite_bgl],
+            push_constant_ranges: &[],
+        });
+        let pipeline = device.create_render_pipeline(&RenderPipelineDescriptor {
+            label: Some("plot composite pipeline"),
+            layout: Some(&layout),
+            vertex: VertexState {
+                module: &shader,
+                entry_point: Some("vs_main"),
+                compilation_options: PipelineCompilationOptions::default(),
+                buffers: &[],
+            },
+            fragment: Some(FragmentState {
+                module: &shader,
+                entry_point: Some("fs_main"),
+                compilation_options: PipelineCompilationOptions::default(),
+                targets: &[Some(ColorTargetState {
+                    format: self.format,
+                    blend: Some(BlendState {
+                        color: BlendComponent {
+                            src_factor: BlendFactor::One,
+                            dst_factor: BlendFactor::OneMinusSrcAlpha,
+                            operation: BlendOperation::Add,
+                        },
+                        alpha: BlendComponent {
+                            src_factor: BlendFactor::One,
+                            dst_factor: BlendFactor::OneMinusSrcAlpha,
+                            operation: BlendOperation::Add,
+                        },
+                    }),
+                    write_mask: ColorWrites::ALL,
+                })],
+            }),
+            primitive: PrimitiveState {
+                topology: PrimitiveTopology::TriangleList,
+                strip_index_format: None,
+                front_face: FrontFace::Ccw,
+                cull_mode: None,
+                polygon_mode: PolygonMode::Fill,
+                unclipped_depth: false,
+                conservative: false,
+            },
+            depth_stencil: None,
+            multisample: MultisampleState::default(),
+            multiview: None,
+            cache: None,
+        });
+        self.pipelines.composite = Some(pipeline);
     }
 
     fn rebuild_markers(&mut self, device: &Device, queue: &Queue, state: &PlotState) {
@@ -1334,6 +1565,10 @@ impl PlotRenderer {
     }
 
     pub fn encode(&self, params: RenderParams) {
+        let Some(msaa_targets) = &self.msaa_targets else {
+            return;
+        };
+
         // Convert bounds to viewport coordinates
         let x = self.bounds.x * self.scale_factor;
         let y = self.bounds.y * self.scale_factor;
@@ -1344,15 +1579,10 @@ impl PlotRenderer {
         {
             let mut pass = params.encoder.begin_render_pass(&RenderPassDescriptor {
                 label: Some("iced_plot main"),
-                color_attachments: &[Some(RenderPassColorAttachment {
-                    view: params.target,
-                    resolve_target: None,
-                    ops: Operations {
-                        load: LoadOp::Load,
-                        store: StoreOp::Store,
-                    },
-                    depth_slice: None,
-                })],
+                color_attachments: &[Some(msaa_attachment(
+                    msaa_targets,
+                    LoadOp::Clear(Color::TRANSPARENT),
+                ))],
                 depth_stencil_attachment: None,
                 occlusion_query_set: None,
                 timestamp_writes: None,
@@ -1423,15 +1653,7 @@ impl PlotRenderer {
         if let Some(pipeline) = self.pipelines.overlay.as_ref() {
             let mut pass = params.encoder.begin_render_pass(&RenderPassDescriptor {
                 label: Some("selection overlay"),
-                color_attachments: &[Some(RenderPassColorAttachment {
-                    view: params.target,
-                    resolve_target: None,
-                    ops: Operations {
-                        load: LoadOp::Load,
-                        store: StoreOp::Store,
-                    },
-                    depth_slice: None,
-                })],
+                color_attachments: &[Some(msaa_attachment(msaa_targets, LoadOp::Load))],
                 depth_stencil_attachment: None,
                 occlusion_query_set: None,
                 timestamp_writes: None,
@@ -1471,15 +1693,7 @@ impl PlotRenderer {
         ) {
             let mut pass = params.encoder.begin_render_pass(&RenderPassDescriptor {
                 label: Some("crosshairs overlay"),
-                color_attachments: &[Some(RenderPassColorAttachment {
-                    view: params.target,
-                    resolve_target: None,
-                    ops: Operations {
-                        load: LoadOp::Load,
-                        store: StoreOp::Store,
-                    },
-                    depth_slice: None,
-                })],
+                color_attachments: &[Some(msaa_attachment(msaa_targets, LoadOp::Load))],
                 depth_stencil_attachment: None,
                 occlusion_query_set: None,
                 timestamp_writes: None,
@@ -1497,6 +1711,34 @@ impl PlotRenderer {
             pass.set_pipeline(pipeline);
             pass.set_vertex_buffer(0, vb.buffer.slice(..));
             pass.draw(0..vb.vertex_count, 0..1);
+        }
+
+        if let Some(pipeline) = self.pipelines.composite.as_ref() {
+            let mut pass = params.encoder.begin_render_pass(&RenderPassDescriptor {
+                label: Some("iced_plot composite"),
+                color_attachments: &[Some(target_attachment(params.target))],
+                depth_stencil_attachment: None,
+                occlusion_query_set: None,
+                timestamp_writes: None,
+            });
+
+            pass.set_viewport(
+                0.0,
+                0.0,
+                msaa_targets.width as f32,
+                msaa_targets.height as f32,
+                0.0,
+                1.0,
+            );
+            pass.set_scissor_rect(
+                params.clip_bounds.x,
+                params.clip_bounds.y,
+                params.clip_bounds.width,
+                params.clip_bounds.height,
+            );
+            pass.set_pipeline(pipeline);
+            pass.set_bind_group(0, &msaa_targets.composite_bind_group, &[]);
+            pass.draw(0..3, 0..1);
         }
     }
 }

--- a/src/plot_widget.rs
+++ b/src/plot_widget.rs
@@ -1622,6 +1622,8 @@ fn update_plot_program<const IS_CANVAS: bool>(
     }
 
     if state.camera != prev_camera || state.bounds != prev_bounds {
+        effects.needs_redraw = true;
+        effects.publish_camera_bounds = true;
         invalidation.all();
     }
 

--- a/src/shaders/composite.wgsl
+++ b/src/shaders/composite.wgsl
@@ -1,0 +1,34 @@
+@group(0) @binding(0)
+var resolved_texture: texture_2d<f32>;
+
+@group(0) @binding(1)
+var resolved_sampler: sampler;
+
+struct VertexOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) uv: vec2<f32>,
+};
+
+@vertex
+fn vs_main(@builtin(vertex_index) vertex_index: u32) -> VertexOutput {
+    var positions = array<vec2<f32>, 3>(
+        vec2<f32>(-1.0, 1.0),
+        vec2<f32>(3.0, 1.0),
+        vec2<f32>(-1.0, -3.0),
+    );
+    var uvs = array<vec2<f32>, 3>(
+        vec2<f32>(0.0, 0.0),
+        vec2<f32>(2.0, 0.0),
+        vec2<f32>(0.0, 2.0),
+    );
+
+    var out: VertexOutput;
+    out.position = vec4<f32>(positions[vertex_index], 0.0, 1.0);
+    out.uv = uvs[vertex_index];
+    return out;
+}
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
+    return textureSample(resolved_texture, resolved_sampler, in.uv);
+}

--- a/src/shaders/markers.wgsl
+++ b/src/shaders/markers.wgsl
@@ -7,8 +7,18 @@ const QUAD_POS: array<vec2<f32>, 4> = array<vec2<f32>, 4>(
 );
 const CIRCLE_RADIUS: f32 = 1.0;
 const EMPTY_CIRCLE_INNER: f32 = 0.7;
-const STAR_ANGLE_MULT: f32 = 5.0;
-const STAR_INNER_SCALE: f32 = 0.3;
+const STAR_POINTS: array<vec2<f32>, 10> = array<vec2<f32>, 10>(
+    vec2<f32>(0.0, 1.0),
+    vec2<f32>(0.264503, 0.364057),
+    vec2<f32>(0.951057, 0.309017),
+    vec2<f32>(0.427975, -0.139058),
+    vec2<f32>(0.587785, -0.809017),
+    vec2<f32>(0.0, -0.45),
+    vec2<f32>(-0.587785, -0.809017),
+    vec2<f32>(-0.427975, -0.139058),
+    vec2<f32>(-0.951057, 0.309017),
+    vec2<f32>(-0.264503, 0.364057),
+);
 const MARKER_SIZE_MODE_MASK: u32 = 1u;
 const MARKER_SIZE_WORLD: u32 = 1u;
 
@@ -76,57 +86,85 @@ fn vs_main(
     return out;
 }
 
+fn segment_distance(point: vec2<f32>, start: vec2<f32>, end: vec2<f32>) -> f32 {
+    let segment = end - start;
+    let t = clamp(dot(point - start, segment) / dot(segment, segment), 0.0, 1.0);
+    return length(point - (start + segment * t));
+}
+
+fn star_signed_distance(point: vec2<f32>) -> f32 {
+    var inside = false;
+    var edge_distance = 1e6;
+    var previous = STAR_POINTS[9];
+
+    for (var i = 0u; i < 10u; i = i + 1u) {
+        let current = STAR_POINTS[i];
+        if ((current.y > point.y) != (previous.y > point.y)) {
+            let intersection_x =
+                (previous.x - current.x) * (point.y - current.y) / (previous.y - current.y)
+                + current.x;
+            if (point.x < intersection_x) {
+                inside = !inside;
+            }
+        }
+        edge_distance = min(edge_distance, segment_distance(point, previous, current));
+        previous = current;
+    }
+
+    if inside {
+        return -edge_distance;
+    }
+    return edge_distance;
+}
+
+fn marker_alpha(sdf: f32) -> f32 {
+    let width = max(fwidth(sdf), 1e-4);
+    return 1.0 - smoothstep(-width, width, sdf);
+}
+
 // Fragment shader
 @fragment
 fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
     let dist = length(in.local_pos);
+    var alpha = 0.0;
 
     // Different marker shapes
     switch in.marker_type {
         case 0u { // Filled Circle
-            if dist <= CIRCLE_RADIUS {
-                return vec4<f32>(in.color.rgb, 1.0);
-            }
+            alpha = marker_alpha(dist - CIRCLE_RADIUS);
         }
         case 1u { // Empty Circle (ring)
-            if dist >= EMPTY_CIRCLE_INNER && dist <= CIRCLE_RADIUS {
-                return vec4<f32>(in.color.rgb, 1.0);
-            }
+            let sdf = max(EMPTY_CIRCLE_INNER - dist, dist - CIRCLE_RADIUS);
+            alpha = marker_alpha(sdf);
         }
         case 2u { // Square
-            if abs(in.local_pos.x) <= CIRCLE_RADIUS && abs(in.local_pos.y) <= CIRCLE_RADIUS {
-                return vec4<f32>(in.color.rgb, 1.0);
-            }
+            let sdf = max(abs(in.local_pos.x), abs(in.local_pos.y)) - CIRCLE_RADIUS;
+            alpha = marker_alpha(sdf);
         }
         case 3u { // Star
-            let angle = atan2(in.local_pos.y, in.local_pos.x);
-            let star_dist = CIRCLE_RADIUS - STAR_INNER_SCALE * abs(sin(angle * STAR_ANGLE_MULT));
-            if dist <= star_dist {
-                return vec4<f32>(in.color.rgb, 1.0);
-            }
+            alpha = marker_alpha(star_signed_distance(in.local_pos));
         }
         case 4u { // Triangle
             let x = in.local_pos.x;
             let y = in.local_pos.y;
             // Equilateral triangle pointing up: base from (-1, -0.866) to (1, -0.866), apex at (0, 0.866)
             // Height/base ratio of √3/2 ≈ 0.866 (truly equilateral), centered at y=0
-            if y >= -0.866 && y <= 0.866 {
-                // Calculate the fraction from base to apex (0 at base, 1 at apex)
-                let fraction = (y + 0.866) / 1.732;
-                // Width decreases linearly from 2 at base to 0 at apex
-                let half_width = 1.0 * (1.0 - fraction);
-                let left_bound = -half_width;
-                let right_bound = half_width;
-                if x >= left_bound && x <= right_bound {
-                    return vec4<f32>(in.color.rgb, 1.0);
-                }
-            }
+            // Calculate the fraction from base to apex (0 at base, 1 at apex)
+            let fraction = (y + 0.866) / 1.732;
+            // Width decreases linearly from 2 at base to 0 at apex
+            let half_width = 1.0 * (1.0 - fraction);
+            let left_sdf = -half_width - x;
+            let right_sdf = x - half_width;
+            let bottom_sdf = -0.866 - y;
+            alpha = marker_alpha(max(max(left_sdf, right_sdf), bottom_sdf));
         }
         default {
             return vec4<f32>(in.color.rgb, 1.0);
         }
     }
 
-    // Transparent for areas outside the marker
-    return vec4<f32>(0.0, 0.0, 0.0, 0.0);
+    if alpha <= 0.0 {
+        return vec4<f32>(0.0, 0.0, 0.0, 0.0);
+    }
+    return vec4<f32>(in.color.rgb, alpha);
 }


### PR DESCRIPTION
Previously, the two rendering paths had several visible differences: Shader markers had jagged edges, Canvas ring/triangle markers did not match Shader output, Canvas grid lines appeared heavier, and Canvas plots did not refresh ticks immediately during resize until the cursor moved over the plot.

This PR updates backend rendering so that:

- Shader markers use smoother antialiasing
- Shader star markers render as an explicit star polygon
- Shader rendering uses a 4x MSAA offscreen target with a composite pass
- Canvas ring and triangle markers match the Shader marker geometry more closely
- Canvas hover/pick highlight masks match marker size more closely
- Canvas grid lines use a thinner stroke to match Shader grid weight
- Canvas plots redraw immediately on resize
- tick positions/labels update live during resize for both Shader and Canvas
- `examples/backends.rs` compares Shader and Canvas rendering side by side

## Demo

`examples/backends.rs` shows all marker styles rendered by both backends.

Before:

https://github.com/user-attachments/assets/34619595-72c5-4afc-b511-6211f26b93f5

Now:

https://github.com/user-attachments/assets/7af76ba7-abea-46ad-ba89-d0c08048950a


