### PR TITLE
fix: preserve paired series fill boundaries

### DIFF
--- a/src/plot_state.rs
+++ b/src/plot_state.rs
@@ -1068,6 +1068,119 @@ fn push_quad_as_triangles(
     vertices.extend_from_slice(&[a0, b0, a1, a1, b0, b1]);
 }
 
+fn series_points_are_paired(a: &[[f64; 2]], b: &[[f64; 2]]) -> bool {
+    fn coordinates_match(a: f64, b: f64) -> bool {
+        const PAIRED_COORD_EPS: f64 = 1e-9;
+        (a - b).abs() <= PAIRED_COORD_EPS * (1.0 + a.abs().max(b.abs()))
+    }
+    fn point_is_finite([x, y]: [f64; 2]) -> bool {
+        x.is_finite() && y.is_finite()
+    }
+
+    if a.len() != b.len() || a.len() < 2 {
+        return false;
+    }
+
+    let mut paired_axes = [true, true];
+    for (&pa, &pb) in a.iter().zip(b) {
+        if !point_is_finite(pa) || !point_is_finite(pb) {
+            return false;
+        }
+
+        paired_axes[0] &= coordinates_match(pa[0], pb[0]);
+        paired_axes[1] &= coordinates_match(pa[1], pb[1]);
+    }
+
+    paired_axes[0] || paired_axes[1]
+}
+
+fn push_paired_series_fill_vertices(
+    vertices: &mut Vec<[f64; 2]>,
+    a: &[[f64; 2]],
+    b: &[[f64; 2]],
+) -> bool {
+    if !series_points_are_paired(a, b) {
+        return false;
+    }
+
+    vertices.reserve_exact((a.len() - 1) * 6);
+    for (a_segment, b_segment) in a.windows(2).zip(b.windows(2)) {
+        push_quad_as_triangles(
+            vertices,
+            a_segment[0],
+            b_segment[0],
+            a_segment[1],
+            b_segment[1],
+        );
+    }
+
+    true
+}
+
+fn push_interpolated_series_fill_vertices(
+    vertices: &mut Vec<[f64; 2]>,
+    a_points: Vec<[f64; 2]>,
+    b_points: Vec<[f64; 2]>,
+) -> Option<()> {
+    let a = monotonic_increasing_x(a_points);
+    let b = monotonic_increasing_x(b_points);
+    if a.len() < 2 || b.len() < 2 {
+        return None;
+    }
+
+    let overlap_min = a.first()?[0].max(b.first()?[0]);
+    let overlap_max = a.last()?[0].min(b.last()?[0]);
+    if overlap_min >= overlap_max {
+        return None;
+    }
+
+    let mut seg_a = find_segment_covering_x(&a, overlap_min)?;
+    let mut seg_b = find_segment_covering_x(&b, overlap_min)?;
+
+    let mut x_curr = overlap_min;
+    let mut y_a_curr = y_at_x_in_segment(&a, seg_a, x_curr)?;
+    let mut y_b_curr = y_at_x_in_segment(&b, seg_b, x_curr)?;
+
+    let eps = 1e-12;
+    loop {
+        let next_a = a.get(seg_a + 1).map(|p| p[0]).unwrap_or(f64::INFINITY);
+        let next_b = b.get(seg_b + 1).map(|p| p[0]).unwrap_or(f64::INFINITY);
+        let x_next = next_a.min(next_b).min(overlap_max);
+
+        if x_next <= x_curr + eps {
+            break;
+        }
+
+        let y_a_next = y_at_x_in_segment(&a, seg_a, x_next)?;
+        let y_b_next = y_at_x_in_segment(&b, seg_b, x_next)?;
+
+        push_quad_as_triangles(
+            vertices,
+            [x_curr, y_a_curr],
+            [x_curr, y_b_curr],
+            [x_next, y_a_next],
+            [x_next, y_b_next],
+        );
+
+        x_curr = x_next;
+        y_a_curr = y_a_next;
+        y_b_curr = y_b_next;
+
+        if x_curr >= overlap_max - eps {
+            break;
+        }
+
+        advance_segment_to_x(&a, &mut seg_a, x_curr);
+        advance_segment_to_x(&b, &mut seg_b, x_curr);
+
+        if seg_a + 1 >= a.len() || seg_b + 1 >= b.len() {
+            break;
+        }
+    }
+
+    Some(())
+}
+
 fn build_fill_span(
     widget: &PlotWidget,
     begin: ShapeId,
@@ -1084,70 +1197,21 @@ fn build_fill_span(
 
     match (begin_endpoint, end_endpoint) {
         (FillEndpoint::Series(sa), FillEndpoint::Series(sb)) => {
-            let a = monotonic_increasing_x(transformed_series_points(
+            let a_points = transformed_series_points(
                 sa,
                 widget.x_axis_scale,
                 widget.y_axis_scale,
                 axis_ranges,
-            ));
-            let b = monotonic_increasing_x(transformed_series_points(
+            );
+            let b_points = transformed_series_points(
                 sb,
                 widget.x_axis_scale,
                 widget.y_axis_scale,
                 axis_ranges,
-            ));
-            if a.len() < 2 || b.len() < 2 {
-                return None;
-            }
+            );
 
-            let overlap_min = a.first()?[0].max(b.first()?[0]);
-            let overlap_max = a.last()?[0].min(b.last()?[0]);
-            if overlap_min >= overlap_max {
-                return None;
-            }
-
-            let mut seg_a = find_segment_covering_x(&a, overlap_min)?;
-            let mut seg_b = find_segment_covering_x(&b, overlap_min)?;
-
-            let mut x_curr = overlap_min;
-            let mut y_a_curr = y_at_x_in_segment(&a, seg_a, x_curr)?;
-            let mut y_b_curr = y_at_x_in_segment(&b, seg_b, x_curr)?;
-
-            let eps = 1e-12;
-            loop {
-                let next_a = a.get(seg_a + 1).map(|p| p[0]).unwrap_or(f64::INFINITY);
-                let next_b = b.get(seg_b + 1).map(|p| p[0]).unwrap_or(f64::INFINITY);
-                let x_next = next_a.min(next_b).min(overlap_max);
-
-                if x_next <= x_curr + eps {
-                    break;
-                }
-
-                let y_a_next = y_at_x_in_segment(&a, seg_a, x_next)?;
-                let y_b_next = y_at_x_in_segment(&b, seg_b, x_next)?;
-
-                push_quad_as_triangles(
-                    &mut vertices,
-                    [x_curr, y_a_curr],
-                    [x_curr, y_b_curr],
-                    [x_next, y_a_next],
-                    [x_next, y_b_next],
-                );
-
-                x_curr = x_next;
-                y_a_curr = y_a_next;
-                y_b_curr = y_b_next;
-
-                if x_curr >= overlap_max - eps {
-                    break;
-                }
-
-                advance_segment_to_x(&a, &mut seg_a, x_curr);
-                advance_segment_to_x(&b, &mut seg_b, x_curr);
-
-                if seg_a + 1 >= a.len() || seg_b + 1 >= b.len() {
-                    break;
-                }
+            if !push_paired_series_fill_vertices(&mut vertices, &a_points, &b_points) {
+                push_interpolated_series_fill_vertices(&mut vertices, a_points, b_points)?;
             }
         }
         (FillEndpoint::Series(series), FillEndpoint::HLine(hline))
@@ -1286,6 +1350,41 @@ mod tests {
 
     use super::*;
     use crate::{PointId, Series};
+
+    #[test]
+    fn paired_series_fill_keeps_step_edges_with_duplicate_x() {
+        let lower = vec![[0.0, 0.0], [0.0, 1.0], [1.0, 1.0], [1.0, 2.0]];
+        let upper = vec![[0.0, 0.0], [0.0, 3.0], [1.0, 3.0], [1.0, 4.0]];
+
+        let mut vertices = Vec::new();
+        assert!(push_paired_series_fill_vertices(
+            &mut vertices,
+            &lower,
+            &upper
+        ));
+
+        assert_eq!(vertices.len(), (lower.len() - 1) * 6);
+        assert_eq!(vertices[0], lower[0]);
+        assert_eq!(vertices[1], upper[0]);
+        assert_eq!(vertices[2], lower[1]);
+    }
+
+    #[test]
+    fn paired_series_fill_supports_y_paired_boundaries() {
+        let lower = vec![[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [2.0, 1.0]];
+        let upper = vec![[3.0, 0.0], [4.0, 0.0], [4.0, 1.0], [5.0, 1.0]];
+
+        let mut vertices = Vec::new();
+        assert!(push_paired_series_fill_vertices(
+            &mut vertices,
+            &lower,
+            &upper
+        ));
+
+        assert_eq!(vertices.len(), (lower.len() - 1) * 6);
+        assert!(vertices.contains(&[3.0, 0.0]));
+        assert!(vertices.contains(&[5.0, 1.0]));
+    }
 
     #[test]
     fn axes_transform_series_maps_to_camera_range_and_skips_autoscale_bounds() {


### PR DESCRIPTION
Previously, series-to-series fills were first reduced to strictly increasing `x` coordinates before interpolation. This dropped duplicate `x` values and could flatten or remove vertical step edges, producing incorrect filled regions for step-like boundaries. It also could not represent boundaries that are naturally paired by `y` instead of `x`.

This PR updates fill generation so that:

- equal-length series with matching paired `x` coordinates are filled segment-by-segment
- equal-length series with matching paired `y` coordinates are also filled segment-by-segment
- duplicate coordinates and vertical step edges are preserved
- non-paired series still use the existing monotonic `x` interpolation fallback

## Demo


Before:

<img width="1022" height="795" alt="Screenshot 2026-06-28 at 01 57 36" src="https://github.com/user-attachments/assets/1fbb2129-d22f-406c-b2e3-ab83f38ded3d" />

Now:

<img width="1022" height="795" alt="Screenshot 2026-06-28 at 01 57 12" src="https://github.com/user-attachments/assets/74b568d7-e9d8-48e6-a823-c238668ad150" />

Demo code:
```rust
//! Demonstrates fill regions between paired series boundaries.
use iced::Element;
use iced_plot::{
    Color, Fill, LineStyle, MarkerStyle, PlotUiMessage, PlotWidget, PlotWidgetBuilder, Series,
};

fn main() -> iced::Result {
    iced::application(new, update, view)
        .font(include_bytes!("fonts/FiraCodeNerdFont-Regular.ttf"))
        .default_font(iced::Font::with_name("FiraCode Nerd Font"))
        .run()
}

fn update(widget: &mut PlotWidget, message: PlotUiMessage) {
    widget.update(message);
}

fn view(widget: &PlotWidget) -> Element<'_, PlotUiMessage> {
    widget.view()
}

fn new() -> PlotWidget {
    let step_lower_positions = vec![
        [0.0, 0.0],
        [1.0, 0.0],
        [1.0, 0.7],
        [2.0, 0.7],
        [2.0, 0.25],
        [3.0, 0.25],
        [3.0, 1.05],
        [4.0, 1.05],
        [4.0, 0.55],
        [5.0, 0.55],
        [5.0, 1.35],
        [6.0, 1.35],
    ];
    let step_upper_positions: Vec<[f64; 2]> = step_lower_positions
        .iter()
        .map(|p| [p[0], p[1] + 1.05])
        .collect();

    let left_positions = vec![
        [7.0, -0.25],
        [7.7, -0.25],
        [7.7, 0.55],
        [7.2, 0.55],
        [7.2, 1.35],
        [7.9, 1.35],
        [7.9, 2.15],
        [7.4, 2.15],
    ];
    let right_positions: Vec<[f64; 2]> =
        left_positions.iter().map(|p| [p[0] + 0.9, p[1]]).collect();

    let step_lower = Series::line_only(
        step_lower_positions,
        LineStyle::solid().with_pixel_width(2.5),
    )
    .with_marker_style(MarkerStyle::circle(3.5))
    .with_color(Color::from_rgb(0.1, 0.45, 0.95))
    .with_label("step lower");
    let step_upper = Series::line_only(
        step_upper_positions,
        LineStyle::solid().with_pixel_width(2.5),
    )
    .with_marker_style(MarkerStyle::circle(3.5))
    .with_color(Color::from_rgb(0.95, 0.35, 0.1))
    .with_label("step upper");
    let step_fill = Fill::new(step_lower.id, step_upper.id)
        .with_color(Color::from_rgba(0.15, 0.6, 0.95, 0.24))
        .with_label("paired x fill");

    let left_boundary = Series::line_only(left_positions, LineStyle::solid().with_pixel_width(2.5))
        .with_marker_style(MarkerStyle::square(3.8))
        .with_color(Color::from_rgb(0.15, 0.62, 0.3))
        .with_label("left boundary");
    let right_boundary =
        Series::line_only(right_positions, LineStyle::solid().with_pixel_width(2.5))
            .with_marker_style(MarkerStyle::square(3.8))
            .with_color(Color::from_rgb(0.6, 0.28, 0.82))
            .with_label("right boundary");
    let side_fill = Fill::new(left_boundary.id, right_boundary.id)
        .with_color(Color::from_rgba(0.3, 0.75, 0.45, 0.24))
        .with_label("paired y fill");

    PlotWidgetBuilder::new()
        .with_x_lim(-0.3, 9.2)
        .with_y_lim(-0.8, 3.2)
        .with_x_label("x")
        .with_y_label("y")
        .add_series(step_lower)
        .add_series(step_upper)
        .add_series(left_boundary)
        .add_series(right_boundary)
        .add_fill(step_fill)
        .add_fill(side_fill)
        .with_cursor_overlay(true)
        .with_crosshairs(true)
        .build()
        .unwrap()
}

```