### PR TITLE
follow mode for streaming plots, append API, and in-pass rendering on Android

### DIFF
--- a/src/grid.rs
+++ b/src/grid.rs
@@ -182,7 +182,7 @@ impl Grid {
         }));
     }
 
-    pub(crate) fn draw<'a>(&'a self, pass: &mut RenderPass<'a>, camera_bind_group: &'a BindGroup) {
+    pub(crate) fn draw(&self, pass: &mut RenderPass<'_>, camera_bind_group: &BindGroup) {
         if self.vertex_count == 0 {
             return;
         }

--- a/src/plot_renderer.rs
+++ b/src/plot_renderer.rs
@@ -1344,6 +1344,85 @@ impl PlotRenderer {
         }
     }
 
+    /// Draws all plot content into an existing render pass (iced's main
+    /// surface pass). The caller (iced's `shader::Primitive::draw` path) has
+    /// already set the viewport to the widget bounds and the scissor to the
+    /// clip bounds — the same state `encode` sets on its own passes.
+    ///
+    /// Rendering in-pass avoids tearing the surface render pass down per plot
+    /// (`Load`/`Store` round-trips). On tile-based mobile GPUs (Mali/Adreno)
+    /// that pass fragmentation triggered driver-level frame corruption: text
+    /// drawn by other passes intermittently disappeared on screens containing
+    /// plots.
+    pub fn draw_in_pass(&self, pass: &mut iced::wgpu::RenderPass<'_>) {
+        // Main content (grid, fills, lines, reference lines, markers)
+        self.grid.draw(pass, &self.camera_bind_group);
+        if let (Some(pipeline), Some(vb)) = (self.pipelines.fill.as_ref(), &self.buffers.fills) {
+            pass.set_pipeline(pipeline);
+            pass.set_bind_group(0, &self.camera_bind_group, &[]);
+            pass.set_vertex_buffer(0, vb.buffer.slice(..));
+            pass.draw(0..vb.vertex_count, 0..1);
+        }
+        if let (Some(pipeline), Some(lb)) = (self.pipelines.line.as_ref(), &self.buffers.lines) {
+            pass.set_pipeline(pipeline);
+            pass.set_bind_group(0, &self.camera_bind_group, &[]);
+            pass.set_vertex_buffer(0, lb.buffer.slice(..));
+            for seg in &lb.segments {
+                pass.draw(seg.first_vertex..seg.first_vertex + seg.vertex_count, 0..1);
+            }
+        }
+        if let (Some(pipeline), Some(lb)) = (self.pipelines.line.as_ref(), &self.buffers.reflines) {
+            pass.set_pipeline(pipeline);
+            pass.set_bind_group(0, &self.camera_bind_group, &[]);
+            pass.set_vertex_buffer(0, lb.buffer.slice(..));
+            for seg in &lb.segments {
+                pass.draw(seg.first_vertex..seg.first_vertex + seg.vertex_count, 0..1);
+            }
+        }
+        if let (Some(pipeline), Some(vb)) = (self.pipelines.marker.as_ref(), &self.buffers.markers)
+        {
+            pass.set_pipeline(pipeline);
+            pass.set_bind_group(0, &self.camera_bind_group, &[]);
+            pass.set_vertex_buffer(0, vb.buffer.slice(..));
+            pass.draw(0..4, 0..vb.vertex_count);
+        }
+        if let (Some(pipeline), Some(vb)) = (
+            self.pipelines.marker.as_ref(),
+            &self.buffers.highlight_markers,
+        ) {
+            pass.set_pipeline(pipeline);
+            pass.set_bind_group(0, &self.camera_bind_group, &[]);
+            pass.set_vertex_buffer(0, vb.buffer.slice(..));
+            pass.draw(0..4, 0..vb.vertex_count);
+        }
+
+        // Selection overlay + highlight mask boxes
+        if let Some(pipeline) = self.pipelines.overlay.as_ref() {
+            pass.set_pipeline(pipeline);
+            if let Some(vb) = &self.buffers.selection {
+                pass.set_vertex_buffer(0, vb.buffer.slice(..));
+                pass.draw(0..vb.vertex_count, 0..1);
+            }
+            if let Some(vb) = &self.buffers.highlight {
+                pass.set_vertex_buffer(0, vb.buffer.slice(..));
+                let quad_count = vb.vertex_count / 4;
+                for i in 0..quad_count {
+                    pass.draw(i * 4..(i + 1) * 4, 0..1);
+                }
+            }
+        }
+
+        // Crosshairs overlay
+        if let (Some(pipeline), Some(vb)) = (
+            self.pipelines.line_overlay.as_ref(),
+            &self.buffers.crosshairs,
+        ) {
+            pass.set_pipeline(pipeline);
+            pass.set_vertex_buffer(0, vb.buffer.slice(..));
+            pass.draw(0..vb.vertex_count, 0..1);
+        }
+    }
+
     pub fn encode(&self, params: RenderParams) {
         // Convert bounds to viewport coordinates
         let x = self.bounds.x * self.scale_factor;

--- a/src/plot_renderer/mod.rs
+++ b/src/plot_renderer/mod.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "canvas")]
 pub mod canvas;
 mod shader;
-pub(crate) use shader::{PlotRenderer, RenderParams};
+pub(crate) use shader::{MSAA_SAMPLE_COUNT, PlotRenderer, RenderParams};
 
 use crate::{
     plot_state::PlotState, plot_widget::HighlightPoint, series::Size,

--- a/src/plot_renderer/shader.rs
+++ b/src/plot_renderer/shader.rs
@@ -10,7 +10,18 @@ use crate::{LineType, Size, camera::CameraUniform, grid::Grid, plot_state::PlotS
 use iced::widget::shader::Viewport;
 use iced::{Rectangle, wgpu::*};
 
-const MSAA_SAMPLE_COUNT: u32 = 4;
+/// MSAA sample count for all plot pipelines.
+///
+/// Android: 1 — plots draw inside iced's surface render pass via
+/// `Primitive::draw` (see `draw_in_pass`), and that pass is single-sampled;
+/// MSAA pipelines would be incompatible ("Incompatible sample count"
+/// validation panic). In-pass rendering is required there because per-plot
+/// pass fragmentation corrupts frames on tile-based GPUs (Mali/Adreno).
+///
+/// Desktop: 4 — plots render through `render()`/`encode` into a dedicated
+/// MSAA offscreen target and composite the resolved texture, so
+/// `Primitive::draw` must return `false` (see `PlotWidget` shader impl).
+pub(crate) const MSAA_SAMPLE_COUNT: u32 = if cfg!(target_os = "android") { 1 } else { 4 };
 
 pub struct RenderParams<'a> {
     pub encoder: &'a mut CommandEncoder,
@@ -430,7 +441,11 @@ impl PlotRenderer {
         }
         self.ensure_overlay_pipeline(device);
         self.ensure_line_overlay_pipeline(device);
-        self.ensure_composite_pipeline(device);
+        // Composite yalnız `encode`'un resolve→hedef blit'inde kullanılır;
+        // pas-içi (MSAA=1) yolda gereksiz.
+        if MSAA_SAMPLE_COUNT > 1 {
+            self.ensure_composite_pipeline(device);
+        }
     }
     fn set_bounds(&mut self, w: u32, h: u32) {
         self.bounds_w = w;
@@ -557,7 +572,12 @@ impl PlotRenderer {
 
         self.set_bounds(bounds_width, bounds_height);
         self.set_scale_factor(scale_factor);
-        self.ensure_msaa_targets(device, viewport_size.width, viewport_size.height);
+        // In-pass path (MSAA=1, Android) never runs `encode`, so the offscreen
+        // MSAA/resolve textures would only waste memory; `encode` self-guards
+        // by early-returning when `msaa_targets` is `None`.
+        if MSAA_SAMPLE_COUNT > 1 {
+            self.ensure_msaa_targets(device, viewport_size.width, viewport_size.height);
+        }
 
         // Sync picking viewport
         self.picking

--- a/src/plot_state.rs
+++ b/src/plot_state.rs
@@ -75,6 +75,10 @@ pub struct PlotState {
     pub(crate) crosshairs_position: Vec2,
     pub(crate) x_axis_formatter: Option<TickFormatter>,
     pub(crate) y_axis_formatter: Option<TickFormatter>,
+    pub(crate) prev_data_max_x: Option<f64>,
+    pub(crate) follow_reset_seen: u64,
+    pub(crate) last_point_y: Option<f64>,
+    pub(crate) prev_last_point_y: Option<f64>,
 }
 
 impl Default for PlotState {
@@ -123,6 +127,10 @@ impl Default for PlotState {
             y_axis_formatter: None,
             x_ticks: Vec::new(),
             y_ticks: Vec::new(),
+            prev_data_max_x: None,
+            follow_reset_seen: 0,
+            last_point_y: None,
+            prev_last_point_y: None,
         }
     }
 }
@@ -153,6 +161,8 @@ impl PlotState {
         let mut series_spans = Vec::new();
         let mut data_min: Option<DVec2> = None;
         let mut data_max: Option<DVec2> = None;
+        let mut rightmost_x: f64 = f64::NEG_INFINITY;
+        let mut rightmost_y: Option<f64> = None;
 
         // Process each series
         for (id, series) in &widget.series {
@@ -178,6 +188,10 @@ impl PlotState {
                 let p = DVec2::new(transformed[0], transformed[1]);
                 data_min = Some(data_min.map_or(p, |m| m.min(p)));
                 data_max = Some(data_max.map_or(p, |m| m.max(p)));
+                if p.x >= rightmost_x {
+                    rightmost_x = p.x;
+                    rightmost_y = Some(p.y);
+                }
 
                 // Only create points if we have markers OR lines (lines need points for geometry)
                 if series.marker_style.is_some() || series.line_style.is_some() {
@@ -274,6 +288,7 @@ impl PlotState {
         self.hlines = hlines.into();
         self.data_min = data_min;
         self.data_max = data_max;
+        self.last_point_y = rightmost_y;
         self.legend_collapsed = widget.legend_collapsed;
         self.x_lim = widget.x_lim;
         self.y_lim = widget.y_lim;
@@ -332,6 +347,28 @@ impl PlotState {
         }
     }
 
+    /// Only scales the Y-axis according to data bounds; does not touch the X camera.
+    /// In follow mode: x is controlled by follow_x, y adapts to data.
+    pub(crate) fn autoscale_y_only(&mut self) {
+        let (Some(data_min), Some(data_max)) = (self.data_min, self.data_max) else {
+            return;
+        };
+        let y_min = if let Some((y_min, _)) = self.y_lim {
+            self.y_axis_scale.data_to_plot(y_min).unwrap_or(data_min.y)
+        } else {
+            data_min.y
+        };
+        let y_max = if let Some((_, y_max)) = self.y_lim {
+            self.y_axis_scale.data_to_plot(y_max).unwrap_or(data_max.y)
+        } else {
+            data_max.y
+        };
+        let range = (y_max - y_min).max(1e-6);
+        let padding = range * 0.05;
+        self.camera.half_extents.y = (range + padding) / 2.0;
+        self.camera.position.y = (y_min + y_max) / 2.0;
+    }
+
     pub(crate) fn update_ticks(
         &mut self,
         x_tick_producer: Option<&TickProducer>,
@@ -384,16 +421,33 @@ impl PlotState {
             None => Vec::new(),
         };
 
+        // Minimum pixel spacing between y-axis tick labels (prevents overlap on small plots)
+        const MIN_Y_TICK_SPACING_PX: f32 = 16.0;
+
         self.y_ticks.clear();
+        let mut raw_y_ticks: Vec<PositionedTick> = Vec::new();
         for tick in y_tick_values {
             let Some(tick_plot) = self.y_axis_scale.data_to_plot(tick.value) else {
                 continue;
             };
-            // Convert world position to screen position
             if let Some(screen_pos) =
                 world_to_screen_position_y(tick_plot, &self.camera, &self.bounds)
             {
-                self.y_ticks.push(PositionedTick { screen_pos, tick });
+                raw_y_ticks.push(PositionedTick { screen_pos, tick });
+            }
+        }
+        // Filter: keep only ticks that are at least MIN_Y_TICK_SPACING_PX apart.
+        // screen_pos is top-to-bottom (increasing = lower on screen), so we
+        // track the last kept tick and skip ticks that are too close to it.
+        let mut last_kept_pos: Option<f32> = None;
+        for tick in raw_y_ticks {
+            let keep = match last_kept_pos {
+                None => true,
+                Some(prev) => (tick.screen_pos - prev).abs() >= MIN_Y_TICK_SPACING_PX,
+            };
+            if keep {
+                last_kept_pos = Some(tick.screen_pos);
+                self.y_ticks.push(tick);
             }
         }
     }
@@ -627,14 +681,26 @@ impl PlotState {
                     // Apply zoom factor based on scroll direction
                     let zoom_factor = if y > 0.0 { 0.95 } else { 1.05 };
 
+                    // Determine zoom axes:
+                    //   Ctrl+Shift → Y-axis only
+                    //   Ctrl+Alt   → X-axis only
+                    //   Ctrl only  → both axes
+                    let zoom_x = !self.modifiers.shift();
+                    let zoom_y = !self.modifiers.alt();
+
                     // Convert cursor position to render coordinates before zoom (without offset)
                     let cursor_render_before = self.camera.screen_to_render(
                         DVec2::new(self.cursor_position.x as f64, self.cursor_position.y as f64),
                         viewport,
                     );
 
-                    // Apply zoom by scaling half_extents
-                    self.camera.half_extents *= zoom_factor;
+                    // Apply zoom by scaling half_extents on selected axes
+                    if zoom_x {
+                        self.camera.half_extents.x *= zoom_factor;
+                    }
+                    if zoom_y {
+                        self.camera.half_extents.y *= zoom_factor;
+                    }
 
                     // Convert cursor position to render coordinates after zoom
                     let cursor_render_after = self.camera.screen_to_render(
@@ -642,10 +708,15 @@ impl PlotState {
                         viewport,
                     );
 
-                    // Adjust camera position (in render space) to keep cursor at same position
+                    // Adjust camera position to keep cursor at the same data point.
+                    // Only adjust the axes that were zoomed.
                     let render_delta = cursor_render_before - cursor_render_after;
-                    // Convert render delta back to world space and adjust camera position
-                    self.camera.position += render_delta;
+                    if zoom_x {
+                        self.camera.position.x += render_delta.x;
+                    }
+                    if zoom_y {
+                        self.camera.position.y += render_delta.y;
+                    }
 
                     self.update_axis_links();
                     needs_redraw = true;

--- a/src/plot_widget.rs
+++ b/src/plot_widget.rs
@@ -69,6 +69,13 @@ pub struct PlotWidget {
     pub(crate) y_axis_label: String,
     pub(crate) x_lim: Option<(f64, f64)>,
     pub(crate) y_lim: Option<(f64, f64)>,
+    /// Follow mode: automatically scale Y-axis on each data update.
+    /// X remains under user control (pan/zoom is preserved).
+    pub(crate) autoscale_y_on_updates: bool,
+    /// Follow mode: locks camera X to the right edge (data_max.x) on each data update.
+    /// Zoom level (half_extents.x) is preserved — user can zoom in/out.
+    pub(crate) follow_right_edge: bool,
+    pub(crate) follow_reset_counter: u64,
     pub(crate) x_axis_scale: AxisScale,
     pub(crate) y_axis_scale: AxisScale,
     pub(crate) x_axis_link: Option<AxisLink>,
@@ -126,6 +133,9 @@ impl PlotWidget {
             y_axis_label: String::new(),
             x_lim: None,
             y_lim: None,
+            autoscale_y_on_updates: false,
+            follow_right_edge: false,
+            follow_reset_counter: 0,
             x_axis_scale: AxisScale::Linear,
             y_axis_scale: AxisScale::Linear,
             x_axis_link: None,
@@ -279,6 +289,26 @@ impl PlotWidget {
     /// If set, these will override autoscaling for the y-axis.
     pub fn set_y_lim(&mut self, min: f64, max: f64) {
         self.y_lim = Some((min, max));
+    }
+
+    /// Clear the x-axis limits, allowing autoscaling to use data bounds.
+    pub fn clear_x_lim(&mut self) {
+        self.x_lim = None;
+    }
+
+    /// Follow mode: only scale Y-axis on each data update.
+    /// X camera is preserved under user pan/zoom state.
+    pub fn set_autoscale_y_on_updates(&mut self, enabled: bool) {
+        self.autoscale_y_on_updates = enabled;
+    }
+
+    /// Follow mode: lock camera X to data right edge (data_max.x) on each update.
+    /// User's zoom level (half_extents.x) is preserved — only position changes.
+    pub fn set_follow_right_edge(&mut self, enabled: bool) {
+        if enabled {
+            self.follow_reset_counter = self.follow_reset_counter.wrapping_add(1);
+        }
+        self.follow_right_edge = enabled;
     }
 
     /// Set the y-axis scale mode.
@@ -1301,6 +1331,30 @@ impl shader::Program<PlotUiMessage> for PlotWidget {
             if self.autoscale_on_updates || limits_changed || first_time_widget_view {
                 // Initial autoscale shouldn't update axis links.
                 state.autoscale(!first_time_widget_view);
+            } else if self.autoscale_y_on_updates {
+                // Takip modu: sadece Y güncellenir, X kamerası kullanıcıda kalır.
+                state.autoscale_y_only();
+            }
+
+            // Takip modu: kamera X ve Y'yi veri delta'sı kadar kaydır; zoom ve kullanıcı konumu korunur.
+            if self.follow_right_edge && !self.autoscale_on_updates {
+                if state.follow_reset_seen != self.follow_reset_counter {
+                    state.prev_data_max_x = None;
+                    state.prev_last_point_y = None;
+                    state.follow_reset_seen = self.follow_reset_counter;
+                }
+                if let Some(data_max) = state.data_max {
+                    if let Some(prev_x) = state.prev_data_max_x {
+                        state.camera.position.x += data_max.x - prev_x;
+                    }
+                    state.prev_data_max_x = Some(data_max.x);
+                }
+                if let Some(last_y) = state.last_point_y {
+                    if let Some(prev_y) = state.prev_last_point_y {
+                        state.camera.position.y += last_y - prev_y;
+                    }
+                    state.prev_last_point_y = Some(last_y);
+                }
             }
 
             state.data_src_version = self.data_version;

--- a/src/plot_widget.rs
+++ b/src/plot_widget.rs
@@ -740,6 +740,37 @@ impl PlotWidget {
         }
     }
 
+    /// Append new points to an existing series, dropping the oldest points so
+    /// the series never exceeds `cap` points (`cap == 0` means unbounded).
+    ///
+    /// Intended for streaming telemetry: callers push only the freshly
+    /// arrived samples instead of rebuilding and re-setting the full window
+    /// on every update. Non-finite points (e.g. `[x, f64::NAN]`) are allowed
+    /// and render as gaps in line series.
+    pub fn append_series_points(&mut self, id: &ShapeId, points: &[[f64; 2]], cap: usize) {
+        if points.is_empty() {
+            return;
+        }
+        if let Some(series) = self.series.get_mut(id) {
+            series.positions.extend_from_slice(points);
+            // Per-point colors must stay aligned with positions: extend with the
+            // series color for the new points, then drop from the FRONT together
+            // with the positions (a plain resize would truncate from the back).
+            if let Some(colors) = &mut series.point_colors {
+                colors.resize(series.positions.len(), series.color);
+            }
+            let len = series.positions.len();
+            if cap > 0 && len > cap {
+                let excess = len - cap;
+                series.positions.drain(..excess);
+                if let Some(colors) = &mut series.point_colors {
+                    colors.drain(..excess);
+                }
+            }
+            self.data_version += 1;
+        }
+    }
+
     /// Set per-point colors for an existing series.
     pub fn set_series_point_colors(&mut self, id: &ShapeId, mut colors: Vec<Color>) {
         if let Some(series) = self.series.get_mut(id) {

--- a/src/plot_widget.rs
+++ b/src/plot_widget.rs
@@ -1559,6 +1559,27 @@ impl shader::Primitive for Primitive {
         renderer.service_picking(self.instance_id, device, queue, &self.plot_widget);
     }
 
+    /// Draws the plot inside iced's main surface render pass.
+    ///
+    /// iced sets the pass viewport/scissor to this primitive's bounds/clip
+    /// before calling — the same state `PlotRenderer::encode` established on
+    /// its own passes. Drawing in-pass avoids per-plot render-pass
+    /// fragmentation of the surface, which corrupted frames (vanishing text)
+    /// on tile-based mobile GPUs. GPU picking is unaffected: it runs from
+    /// `prepare` with its own encoder/submission.
+    fn draw(
+        &self,
+        renderer_state: &Self::Pipeline,
+        render_pass: &mut iced::wgpu::RenderPass<'_>,
+    ) -> bool {
+        if let Some(renderer) = renderer_state.renderers.get(&self.instance_id) {
+            renderer.draw_in_pass(render_pass);
+        }
+        true
+    }
+
+    /// Fallback path (unused: `draw` always returns `true`). Kept for
+    /// API completeness and easy A/B testing against the in-pass path.
     fn render(
         &self,
         renderer_state: &Self::Pipeline,

--- a/src/plot_widget.rs
+++ b/src/plot_widget.rs
@@ -1889,19 +1889,28 @@ impl shader::Primitive for Primitive {
     /// fragmentation of the surface, which corrupted frames (vanishing text)
     /// on tile-based mobile GPUs. GPU picking is unaffected: it runs from
     /// `prepare` with its own encoder/submission.
+    ///
+    /// Only valid when the pipelines are single-sampled: iced's surface pass
+    /// has sample count 1, so with MSAA pipelines (desktop, 4x) this returns
+    /// `false` and iced falls back to `render`, which draws into a dedicated
+    /// MSAA offscreen target and composites the resolved texture.
     fn draw(
         &self,
         renderer_state: &Self::Pipeline,
         render_pass: &mut iced::wgpu::RenderPass<'_>,
     ) -> bool {
+        if crate::plot_renderer::MSAA_SAMPLE_COUNT > 1 {
+            return false;
+        }
         if let Some(renderer) = renderer_state.renderers.get(&self.instance_id) {
             renderer.draw_in_pass(render_pass);
         }
         true
     }
 
-    /// Fallback path (unused: `draw` always returns `true`). Kept for
-    /// API completeness and easy A/B testing against the in-pass path.
+    /// MSAA path (desktop): dedicated offscreen MSAA pass + resolve +
+    /// composite. Android (MSAA=1) never reaches this — `draw` handles it
+    /// in-pass.
     fn render(
         &self,
         renderer_state: &Self::Pipeline,


### PR DESCRIPTION
## Summary

This PR adds streaming-oriented features to the plot widget and fixes a frame-corruption issue on Android (tile-based GPUs).

### 1. Follow mode (`plot_state.rs`, `plot_widget.rs`)
Two new opt-in behaviors for live/streaming plots:

- **`set_autoscale_y_on_updates(bool)`** — on each data update only the Y-axis is rescaled to the data bounds (respecting `y_lim`); the X camera stays wherever the user panned/zoomed it (`autoscale_y_only`).
- **`set_follow_right_edge(bool)`** — the camera tracks the newest data by shifting X by the `data_max.x` delta (and Y by the last point's delta) on each update. The user's zoom level (`half_extents`) is never touched, so you can zoom in/out while following. Re-enabling follow bumps a reset counter so stale deltas from a previous session aren't applied.
- **`clear_x_lim()`** — clears a previously set X limit so autoscaling can use data bounds again.

### 2. Streaming append API (`plot_widget.rs`)
- **`append_series_points(id, points, cap)`** — appends only the freshly arrived samples instead of rebuilding the whole window every update. When `cap > 0`, oldest points are dropped from the front; per-point colors are kept aligned with positions. Non-finite points (e.g. `[x, NAN]`) are allowed and render as gaps.

### 3. Android rendering fix (`shader.rs`, `plot_widget.rs`, `plot_renderer/mod.rs`)
Rendering each plot through its own offscreen pass fragmented iced's surface render pass, which triggered driver-level frame corruption on tile-based mobile GPUs (Mali/Adreno) — text from other passes intermittently vanished on screens containing plots.

- Plots now implement `shader::Primitive::draw` and render **inside iced's main surface pass** (`draw_in_pass`) when pipelines are single-sampled.
- `MSAA_SAMPLE_COUNT` is now platform-conditional: **1 on Android** (surface pass is single-sampled; MSAA pipelines would panic with "Incompatible sample count") and **4 on desktop**, where `draw` returns `false` and iced falls back to the existing `render()` offscreen-MSAA + composite path.
- On the in-pass path the offscreen MSAA/resolve textures and the composite pipeline are no longer created (memory savings); `encode` self-guards by early-returning when targets are absent.
- GPU picking is unaffected — it still runs from `prepare` with its own encoder.

### 4. Smaller UX improvements
- **Axis-selective zoom**: scroll-zoom now honors modifiers — Shift = Y-only, Alt = X-only, none = both. The cursor anchor adjustment is applied only to the zoomed axes.
- **Y-tick decluttering**: y-axis tick labels closer than 16 px are skipped, preventing label overlap on small plots.

## Breaking changes
None — all new behaviors are opt-in; desktop rendering path is unchanged (still 4x MSAA offscreen).

## Test notes
- Desktop: verify plots still render with 4x MSAA and zoom/pan/selection behave as before.
- Android: verify screens containing plots no longer show vanishing text, and that plots render correctly inside the surface pass.
- Streaming: enable `set_follow_right_edge(true)` + `set_autoscale_y_on_updates(true)` with `append_series_points` and confirm the view tracks incoming data while manual zoom is preserved.
